### PR TITLE
Various fixes, plus install additional apt packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM ubuntu:latest
 
 COPY requirements.txt /requirements.txt
 
-RUN apt update && apt install -y --no-install-recommends\
+RUN apt update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt install -y --no-install-recommends\
+    tzdata \
     clang-tidy-6.0 \
     clang-tidy-7 \
     clang-tidy-8 \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ jobs:
   - default: `"*.[ch],*.[ch]xx,*.[ch]pp,*.[ch]++,*.cc,*.hh"`
 - `exclude`: Comma-separated list of files or patterns to exclude
   - default: ''
+- `apt_packages`: Comma-separated list of apt packages to install
+  - default: ''
 
 ## Outputs:
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ jobs:
       run: exit 1
 ```
 
+## Limitations
+
+This is a Docker container-based Action because it needs to install
+some system packages (the different `clang-tidy` versions) as well as
+some Python packages. This that means that there's a two-three minutes
+start-up in order to build the Docker container. If you need to
+install some additional packages you can pass them via the
+`apt_packages` argument.
+
+GitHub only mounts the `GITHUB_WORKSPACE` directory (that is, the
+default place where it clones your repository) on the container. If
+you install additional libraries/packages yourself, you'll need to
+make sure they are in this directory, otherwise they won't be
+accessible from inside this container.
+
 ## Inputs
 
 - `token`: Authentication token

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Comma-separated list of files or patterns to exclude'
     required: false
     default: ''
+  apt_packages:
+    description: 'Comma-separated list of apt packages to install'
+    required: false
+    default: ''
   pr:
     default: ${{ github.event.pull_request.number }}
   repo:
@@ -48,3 +52,4 @@ runs:
     - --clang_tidy_checks=${{ inputs.clang_tidy_checks }}
     - --include ${{ inputs.include }}
     - --exclude ${{ inputs.exclude }}
+    - --apt-packages=${{ inputs.apt_packages }}

--- a/review.py
+++ b/review.py
@@ -125,16 +125,16 @@ def get_clang_tidy_warnings(
     print(f"Running:\n\t{command}")
 
     try:
-        child = subprocess.run(command, capture_output=True, shell=True, check=True,)
+        output = subprocess.run(
+            command, capture_output=True, shell=True, check=True, encoding="utf-8"
+        )
     except subprocess.CalledProcessError as e:
         print(
-            f"\n\nclang-tidy failed with return code {e.returncode} and error:\n{e.stderr.decode('utf-8')}"
+            f"\n\nclang-tidy failed with return code {e.returncode} and error:\n{e.stderr}\nOutput was:\n{e.stdout}"
         )
         raise
 
-    output = child.stdout.decode("utf-8", "ignore")
-
-    return output.splitlines()
+    return output.stdout.splitlines()
 
 
 def post_lgtm_comment(pull_request):

--- a/review.py
+++ b/review.py
@@ -19,6 +19,7 @@ import unidiff
 from github import Github
 
 BAD_CHARS_APT_PACKAGES_PATTERN = "[;&|($]"
+DIFF_HEADER_LINE_LENGTH = 5
 
 
 def make_file_line_lookup(diff):
@@ -33,7 +34,9 @@ def make_file_line_lookup(diff):
         for hunk in file:
             for line in hunk:
                 if not line.is_removed:
-                    lookup[filename][line.target_line_no] = line.diff_line_no - 5
+                    lookup[filename][line.target_line_no] = (
+                        line.diff_line_no - DIFF_HEADER_LINE_LENGTH
+                    )
     return lookup
 
 

--- a/review.py
+++ b/review.py
@@ -13,8 +13,9 @@ import os
 from operator import itemgetter
 import pprint
 import re
-import subprocess
 import requests
+import subprocess
+import textwrap
 import unidiff
 from github import Github
 
@@ -61,7 +62,7 @@ def make_review(contents, lookup):
             comment_body = f"""{warning.strip().replace("'", "`")}
 
 ```cpp
-{body.strip()}
+{textwrap.dedent(body).strip()}
 ```
 """
             comments.append(

--- a/review.py
+++ b/review.py
@@ -44,6 +44,10 @@ def make_review(contents, lookup):
     comments = []
     for num, line in enumerate(contents):
         if "warning" in line:
+            if line.startswith("warning"):
+                # Some warnings don't have the file path, skip them
+                # FIXME: Find a better way to handle this
+                continue
             full_path, source_line, _, warning = line.split(":", maxsplit=3)
             rel_path = os.path.relpath(full_path, root)
             body = ""

--- a/review.py
+++ b/review.py
@@ -186,8 +186,8 @@ def post_review(pull_request, review):
         print("Everything already posted!")
         return
 
-    print("\nNew comments to post:")
-    pprint.pprint(review)
+    review_string = pprint.pformat(review)
+    print("\nNew comments to post:\n", review_string, flush=True)
 
     pull_request.create_review(**review)
 
@@ -225,9 +225,13 @@ def main(
     clang_tidy_warnings = get_clang_tidy_warnings(
         line_ranges, build_dir, clang_tidy_checks, clang_tidy_binary, " ".join(files)
     )
+    print("clang-tidy had the following warnings:\n", clang_tidy_warnings, flush=True)
 
     lookup = make_file_line_lookup(diff)
     review = make_review(clang_tidy_warnings, lookup)
+
+    review_string = pprint.pformat(review)
+    print("Created the following review:\n", review_string, flush=True)
 
     github = Github(token)
     repo = github.get_repo(f"{repo}")
@@ -237,8 +241,7 @@ def main(
         post_lgtm_comment(pull_request)
         return
 
-    print("Posting a review:")
-    pprint.pprint(review)
+    print("Posting the review", flush=True)
     post_review(pull_request, review)
 
 

--- a/review.py
+++ b/review.py
@@ -92,7 +92,17 @@ def get_pr_diff(repo, pr_number, token):
     pr_diff_response = requests.get(url, headers=headers)
     pr_diff_response.raise_for_status()
 
-    return unidiff.PatchSet(pr_diff_response.text)
+    # PatchSet is the easiest way to construct what we want, but the
+    # diff_line_no property on lines is counted from the top of the
+    # whole PatchSet, whereas GitHub is expecting the "position"
+    # property to be line count within each file's diff. So we need to
+    # do this little bit of faff to get a list of file-diffs with
+    # their own diff_line_no range
+    diff = [
+        unidiff.PatchSet(str(file))[0]
+        for file in unidiff.PatchSet(pr_diff_response.text)
+    ]
+    return diff
 
 
 def get_line_ranges(diff):

--- a/review.py
+++ b/review.py
@@ -41,8 +41,7 @@ def make_file_line_lookup(diff):
 
 
 def make_review(contents, lookup):
-    """Construct a Github PR review given some warnings and a lookup table
-    """
+    """Construct a Github PR review given some warnings and a lookup table"""
     root = os.getcwd()
     comments = []
     for num, line in enumerate(contents):
@@ -82,9 +81,7 @@ def make_review(contents, lookup):
 
 
 def get_pr_diff(repo, pr_number, token):
-    """Download the PR diff
-
-    """
+    """Download the PR diff, return a list of PatchedFile"""
 
     headers = {
         "Accept": "application/vnd.github.v3.diff",
@@ -138,8 +135,7 @@ def get_line_ranges(diff):
 def get_clang_tidy_warnings(
     line_filter, build_dir, clang_tidy_checks, clang_tidy_binary, files
 ):
-    """Get the clang-tidy warnings
-    """
+    """Get the clang-tidy warnings"""
 
     command = f"{clang_tidy_binary} -p={build_dir} -checks={clang_tidy_checks} -line-filter={line_filter} {files}"
     print(f"Running:\n\t{command}")
@@ -158,9 +154,7 @@ def get_clang_tidy_warnings(
 
 
 def post_lgtm_comment(pull_request):
-    """Post a "LGTM" comment if everything's clean, making sure not to spam
-
-    """
+    """Post a "LGTM" comment if everything's clean, making sure not to spam"""
 
     BODY = 'clang-tidy review says "All clean, LGTM! :+1:"'
 
@@ -175,9 +169,7 @@ def post_lgtm_comment(pull_request):
 
 
 def post_review(pull_request, review):
-    """Post the review on the pull_request, making sure not to spam
-
-    """
+    """Post the review on the pull_request, making sure not to spam"""
 
     comments = pull_request.get_review_comments()
 


### PR DESCRIPTION
- Replace absolute paths in `compile_commands.json` if it exists
  - Needed due to container-based Actions being mounted in a different location, and `clang-tidy` not accepting relative paths
- Add argument to install additional apt packages
  - Needed to bring in headers for third-party dependencies
- Fix for PRs with multiple files
- Fix for whitespace in code-blocks in comments