### PR TITLE
Fix issue with creating a review with too many comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ you install additional libraries/packages yourself, you'll need to
 make sure they are in this directory, otherwise they won't be
 accessible from inside this container.
 
+It seems the GitHub API might only accept a limited number of comments
+at once, so `clang-tidy-review` will only attempt to post the first
+`max_comments` of them (default 25, as this has worked for me).
+
 ## Inputs
 
 - `token`: Authentication token
@@ -68,6 +72,8 @@ accessible from inside this container.
   - default: ''
 - `apt_packages`: Comma-separated list of apt packages to install
   - default: ''
+- `max_comments`: Maximum number of comments to post at once
+  - default: '25'
 
 ## Outputs:
 

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: 'Comma-separated list of apt packages to install'
     required: false
     default: ''
+  max_comments:
+    description: 'Maximum number of comments to post at once'
+    required: false
+    default: '25'
   pr:
     default: ${{ github.event.pull_request.number }}
   repo:


### PR DESCRIPTION
It seems GitHub will only let you post so many review comments at once. I'm not sure of the exact number, so I've made it an input parameter. Could do something like post `n` at a time, looping till they're all done, but I figure posting 100 comments is a bit spammy anyway. Triggering another run of this action will post the next `max_comments` comments, so that's a nice compromise at least