### PR TITLE
Avoid apt warning when building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY requirements.txt /requirements.txt
 
 RUN apt update && \
     DEBIAN_FRONTEND=noninteractive \
-    apt install -y --no-install-recommends\
+    apt-get install -y --no-install-recommends\
     tzdata \
     clang-tidy-6.0 \
     clang-tidy-7 \


### PR DESCRIPTION
Fixes `WARNING: apt does not have a stable CLI interface. Use with caution in scripts.`