### PR TITLE
Suggest fixits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyGithub~=1.51
 unidiff~=0.6.0
 requests~=2.23
+pyyaml~=5.4

--- a/review.py
+++ b/review.py
@@ -253,8 +253,12 @@ def make_comment_from_diagnostic(diagnostic_name, diagnostic, offset_lookup):
                 # in order to make a nice diff block. The extra
                 # whitespace is so the multiline dedent-ed block below
                 # doesn't come out weird.
-                new_line = "\n                    ".join(
+                whitespace = "\n                    "
+                new_line = whitespace.join(
                     [f"+ {line}" for line in new_line.splitlines()]
+                )
+                old_line = whitespace.join(
+                    [f"- {line}" for line in old_line.splitlines()]
                 )
 
                 rel_path = os.path.relpath(replacement_set[0]["FilePath"], root)
@@ -263,7 +267,7 @@ def make_comment_from_diagnostic(diagnostic_name, diagnostic, offset_lookup):
 
                     {rel_path}:{replacement_line_num}:
                     ```diff
-                    - {old_line}
+                    {old_line}
                     {new_line}
                     ```
                     """

--- a/review.py
+++ b/review.py
@@ -286,7 +286,7 @@ def format_notes(notes, offset_lookup):
         source_line = read_one_line(filename, offset_lookup[filename][line_num])
 
         path = try_relative(filename)
-        message = f"*{path}:{line_num}:* {note['Message']}"
+        message = f"**{path}:{line_num}:** {note['Message']}"
         code = format_ordinary_line(source_line, line_offset)
         code_blocks += f"{message}\n{code}"
 

--- a/review.py
+++ b/review.py
@@ -6,6 +6,7 @@
 # See LICENSE for more information
 
 import argparse
+import datetime
 import itertools
 import fnmatch
 import json
@@ -151,6 +152,7 @@ def get_clang_tidy_warnings(
     command = f"{clang_tidy_binary} -p={build_dir} -checks={clang_tidy_checks} -line-filter={line_filter} {files}"
     print(f"Running:\n\t{command}")
 
+    start = datetime.datetime.now()
     try:
         output = subprocess.run(
             command, capture_output=True, shell=True, check=True, encoding="utf-8"
@@ -160,6 +162,9 @@ def get_clang_tidy_warnings(
             f"\n\nclang-tidy failed with return code {e.returncode} and error:\n{e.stderr}\nOutput was:\n{e.stdout}"
         )
         raise
+    end = datetime.datetime.now()
+
+    print(f"Took: {end - start}")
 
     return output.stdout.splitlines()
 

--- a/review.py
+++ b/review.py
@@ -597,7 +597,11 @@ def main(
 
     diff_lookup = make_file_line_lookup(diff)
     offset_lookup = make_file_offset_lookup(files)
-    review = make_review(clang_tidy_warnings["Diagnostics"], diff_lookup, offset_lookup)
+
+    with message_group("Creating review from warnings"):
+        review = make_review(
+            clang_tidy_warnings["Diagnostics"], diff_lookup, offset_lookup
+        )
 
     print("Created the following review:\n", pprint.pformat(review), flush=True)
 


### PR DESCRIPTION
Closes #4 

Uses the `--export-fixes` argument to read in a yaml file of fixes, which are more easily turned into github suggestions.