### PR TITLE
#20 - Fix path replace problem

### DIFF
--- a/review.py
+++ b/review.py
@@ -350,21 +350,17 @@ if __name__ == "__main__":
         original_directory = compile_commands[0]["directory"]
 
         # directory should either end with the build directory,
-        # unless it's '.', in which case use all of the directory,
-        # excluding the trailing /.
+        # unless it's '.', in which case use all of directory
         if original_directory.endswith(args.build_dir):
             build_dir_index = -(len(args.build_dir) + 1)
+            basedir = original_directory[:build_dir_index]
         elif args.build_dir == ".":
-            if (original_directory.endswith("/")):
-                build_dir_index = -1
-            else:
-                build_dir_index = len(original_directory) + 1
+            basedir = original_directory
         else:
             raise RuntimeError(
                 f"compile_commands.json contains absolute paths that I don't know how to deal with: '{original_directory}'"
             )
 
-        basedir = original_directory[:build_dir_index]
         newbasedir = os.getcwd()
 
         print(f"Replacing '{basedir}' with '{newbasedir}'", flush=True)

--- a/review.py
+++ b/review.py
@@ -350,11 +350,15 @@ if __name__ == "__main__":
         original_directory = compile_commands[0]["directory"]
 
         # directory should either end with the build directory,
-        # unless it's '.', in which case use all of directory
+        # unless it's '.', in which case use all of the directory,
+        # excluding the trailing /.
         if original_directory.endswith(args.build_dir):
             build_dir_index = -(len(args.build_dir) + 1)
         elif args.build_dir == ".":
-            build_dir_index = -1
+            if (original_directory.endswith("/")):
+                build_dir_index = -1
+            else:
+                build_dir_index = len(original_directory) + 1
         else:
             raise RuntimeError(
                 f"compile_commands.json contains absolute paths that I don't know how to deal with: '{original_directory}'"


### PR DESCRIPTION
The problem I was having with your Action was related to the compile_commands.json "directory" entry you make use of on line 350.  I'm guessing that you assumed that the directory is always terminated with a /.  In my case it is not.  This leads to an error later when replacing that directory path which does not exist.  I noticed other people saw the same thing, so I'm proposing this simple change to check that you're really removing a /.  Works for me now.

