### PR TITLE
Add argument to pass in CMake command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN apt update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends\
+    build-essential cmake git \
     tzdata \
     clang-tidy-6.0 \
     clang-tidy-7 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,5 @@ RUN apt update && \
     pip3 install -r requirements.txt
 
 COPY review.py /review.py
-COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/review.py"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ start-up in order to build the Docker container. If you need to
 install some additional packages you can pass them via the
 `apt_packages` argument.
 
+Except for very simple projects, a `compile_commands.json` file is necessary for
+clang-tidy to find headers, set preprocessor macros, and so on. You can generate
+one as part of this Action by setting `cmake_command` to something like `cmake
+. -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=on`.
+
 GitHub only mounts the `GITHUB_WORKSPACE` directory (that is, the
 default place where it clones your repository) on the container. If
 you install additional libraries/packages yourself, you'll need to
@@ -71,11 +76,17 @@ at once, so `clang-tidy-review` will only attempt to post the first
   - default: '11'
 - `clang_tidy_checks`: List of checks
   - default: `'-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*'`
+- `config_file`: Path to clang-tidy config file. If set, the config file is used
+  instead of `clang_tidy_checks`
+  - default: ''
 - `include`: Comma-separated list of files or patterns to include
   - default: `"*.[ch],*.[ch]xx,*.[ch]pp,*.[ch]++,*.cc,*.hh"`
 - `exclude`: Comma-separated list of files or patterns to exclude
   - default: ''
 - `apt_packages`: Comma-separated list of apt packages to install
+  - default: ''
+- `cmake_command`: A CMake command to configure your project and generate
+  `compile_commands.json` in `build_dir`
   - default: ''
 - `max_comments`: Maximum number of comments to post at once
   - default: '25'

--- a/action.yml
+++ b/action.yml
@@ -66,4 +66,4 @@ runs:
     - --include='${{ inputs.include }}'
     - --exclude='${{ inputs.exclude }}'
     - --apt-packages=${{ inputs.apt_packages }}
-    - --cmake-command='${{ inputs.cmake_command }}'
+    - --cmake-command='"${{ inputs.cmake_command }}"'

--- a/action.yml
+++ b/action.yml
@@ -66,4 +66,4 @@ runs:
     - --include='${{ inputs.include }}'
     - --exclude='${{ inputs.exclude }}'
     - --apt-packages=${{ inputs.apt_packages }}
-    - --cmake-command=${{ inputs.cmake_command }}
+    - --cmake-command='${{ inputs.cmake_command }}'

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: 'Comma-separated list of apt packages to install'
     required: false
     default: ''
+  cmake_command:
+    description: 'If set, run CMake as part of the action using this command'
+    required: false
+    default: ''
   max_comments:
     description: 'Maximum number of comments to post at once'
     required: false
@@ -62,3 +66,4 @@ runs:
     - --include='${{ inputs.include }}'
     - --exclude='${{ inputs.exclude }}'
     - --apt-packages=${{ inputs.apt_packages }}
+    - --cmake-command=${{ inputs.cmake_command }}

--- a/action.yml
+++ b/action.yml
@@ -66,4 +66,4 @@ runs:
     - --include='${{ inputs.include }}'
     - --exclude='${{ inputs.exclude }}'
     - --apt-packages=${{ inputs.apt_packages }}
-    - --cmake-command='"${{ inputs.cmake_command }}"'
+    - --cmake-command='${{ inputs.cmake_command }}'

--- a/review.py
+++ b/review.py
@@ -382,7 +382,7 @@ if __name__ == "__main__":
         apt_packages = re.split(BAD_CHARS_APT_PACKAGES_PATTERN, args.apt_packages)[
             0
         ].split(",")
-        print("Installing additional packages:", apt_packages)
+        print("Installing additional packages:", apt_packages, flush=True)
         subprocess.run(
             ["apt", "install", "-y", "--no-install-recommends"] + apt_packages
         )
@@ -393,7 +393,7 @@ if __name__ == "__main__":
     # the compile_commands.json file are going to be correct
     if args.cmake_command:
         cmake_command = strip_enclosing_quotes(args.cmake_command)
-        print(f"Running cmake: {cmake_command}")
+        print(f"Running cmake: {cmake_command}", flush=True)
         subprocess.run(cmake_command, shell=True, check=True)
 
     elif os.path.exists(build_compile_commands):

--- a/review.py
+++ b/review.py
@@ -343,6 +343,12 @@ if __name__ == "__main__":
         default="",
     )
     parser.add_argument(
+        "--cmake-command",
+        help="If set, run CMake as part of the action with this command",
+        type=str,
+        default="",
+    )
+    parser.add_argument(
         "--max-comments",
         help="Maximum number of comments to post at once",
         type=int,
@@ -371,7 +377,13 @@ if __name__ == "__main__":
 
     build_compile_commands = f"{args.build_dir}/compile_commands.json"
 
-    if os.path.exists(build_compile_commands):
+    # If we run CMake as part of the action, then we know the paths in
+    # the compile_commands.json file are going to be correct
+    if args.cmake_command:
+        print(f"Running cmake: {args.cmake_command}")
+        subprocess.run(args.cmake_command, shell=True, check=True)
+
+    elif os.path.exists(build_compile_commands):
         print(f"Found '{build_compile_commands}', updating absolute paths")
         # We might need to change some absolute paths if we're inside
         # a docker container
@@ -381,7 +393,7 @@ if __name__ == "__main__":
         original_directory = compile_commands[0]["directory"]
 
         # directory should either end with the build directory,
-        # unless it's '.', in which case use all of directory
+        # unless it's '.', in which case use original directory
         if original_directory.endswith(args.build_dir):
             build_dir_index = -(len(args.build_dir) + 1)
             basedir = original_directory[:build_dir_index]


### PR DESCRIPTION
Closes #22 

~Possibly fix for #14~

By running the CMake command inside the container when the Action is run, we can avoid having to faff about trying to fix the paths in `compile_commands.json`.

We can also speed up Workflows a bit by not needing to install `apt` packages both in the Workflow _and_ inside the docker container.