### PR TITLE
Add an example of a config_file invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,7 @@ at once, so `clang-tidy-review` will only attempt to post the first
   - default: '11'
 - `clang_tidy_checks`: List of checks
   - default: `'-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*'`
-- `config_file`: Path to clang-tidy config file. If set, the config file is used
-  instead of `clang_tidy_checks`
+- `config_file`: Path to clang-tidy config file, replaces `clang_tidy_checks`. Example for a .clang-tidy file at the root of the repo: `config_file: '.clang-tidy'`
   - default: ''
 - `include`: Comma-separated list of files or patterns to include
   - default: `"*.[ch],*.[ch]xx,*.[ch]pp,*.[ch]++,*.cc,*.hh"`


### PR DESCRIPTION
Having a `.clang-tidy` file at the root of the repo is standard practice - ideally it would be [supported out of the box](https://github.com/ZedThree/clang-tidy-review/issues/29), but failing that also providing an easy copy/pasteable way to set it up would be good.