### PR TITLE
Removed raise in case of clang-tidy error

### DIFF
--- a/review.py
+++ b/review.py
@@ -543,7 +543,6 @@ def get_clang_tidy_warnings(
         print(
             f"\n\nclang-tidy failed with return code {e.returncode} and error:\n{e.stderr}\nOutput was:\n{e.stdout}"
         )
-        raise
     end = datetime.datetime.now()
 
     print(f"Took: {end - start}")


### PR DESCRIPTION
I removed the raise mentioned in #39

The amazing thing is: Now the action out of the box displays `clang-diagnostic-*` warnings! I am surprised, but it's just as it should be now 🥳

here you can see a test PR with my fork that caused a compile error that was however properly posted by clang-tidy-review afterwards:
https://github.com/FlorianReimold/ecal/pull/12

_I have not tested for side-effects. Not sure if that `raise` had any important role_