### PR TITLE
Fixed handling of relative paths

### DIFF
--- a/review.py
+++ b/review.py
@@ -791,7 +791,7 @@ if __name__ == "__main__":
         ].split(",")
         with message_group(f"Installing additional packages: {apt_packages}"):
             subprocess.run(
-                ["apt", "install", "-y", "--no-install-recommends"] + apt_packages
+                ["apt-get", "install", "-y", "--no-install-recommends"] + apt_packages
             )
 
     build_compile_commands = f"{args.build_dir}/compile_commands.json"

--- a/review.py
+++ b/review.py
@@ -805,12 +805,6 @@ if __name__ == "__main__":
         default=25,
     )
     parser.add_argument("--token", help="github auth token")
-    
-    parser.add_argument(
-        "--restrict-to-compile-command-json",
-        help = "Only check files that are specified in the compile_commands.json file."
-    )
-    
     parser.add_argument(
         "--dry-run", help="Run and generate review, but don't post", action="store_true"
     )

--- a/review.py
+++ b/review.py
@@ -558,7 +558,7 @@ def get_clang_tidy_warnings(
     if config_file != "":
         config = f"-config-file=\"{config_file}\""
     else:
-        config = f"-checks=\"{clang_tidy_checks}\""
+        config = f"-checks={clang_tidy_checks}"
 
     print(f"Using config: {config}")
 


### PR DESCRIPTION
Fixed handling of relative paths. If clang-tidy returns a relative path, it means that it is relative to the build dir, but clang-tidy-review interpreted it as being relative to the current working directory, which is the git checkout dir.

This is fixed, now, by always interpreting relative paths as relative to the build directory and converting them to absolute paths.

Fixes #41