### PR TITLE
Convert all replacement FilePaths to absolute paths in `collate_replacement_sets()`

### DIFF
--- a/post/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/__init__.py
@@ -322,6 +322,14 @@ def collate_replacement_sets(diagnostic, offset_lookup):
     # First, make sure each replacement contains "LineNumber", and
     # "EndLineNumber" in case it spans multiple lines
     for replacement in diagnostic["Replacements"]:
+        # Sometimes, the FilePath may include ".." in "." as a path component
+        # However, file paths are stored in the offset table only after being
+        # converted to an abs path, in which case the stored path will differ
+        # from the FilePath and we'll end up looking for a path that's not in
+        # the lookup dict
+        # To fix this, we'll convert all the FilePaths to absolute paths
+        replacement["FilePath"] = os.path.abspath(replacement["FilePath"])
+
         # It's possible the replacement is needed in another file?
         # Not really sure how that could come about, but let's
         # cover our behinds in case it does happen:


### PR DESCRIPTION
The `clang-tidy` output can sometimes output sorta-relative replacement FilePaths (with `..` and `.` as path components), which leads to a `KeyError`:

```
Traceback (most recent call last):
  File "/action/review.py", line 205, in <module>
    main(
  File "/action/review.py", line 46, in main
    review = create_review(
  File "/action/post/clang_tidy_review/__init__.py", line 673, in create_review
    review = create_review_file(
  File "/action/post/clang_tidy_review/__init__.py", line 568, in create_review_file
    comment_body, end_line = make_comment_from_diagnostic(
  File "/action/post/clang_tidy_review/__init__.py", line 532, in make_comment_from_diagnostic
    code_blocks, end_line = format_diff_line(
  File "/action/post/clang_tidy_review/__init__.py", line 428, in format_diff_line
    old_line, new_line = replace_one_line(
  File "/action/post/clang_tidy_review/__init__.py", line 367, in replace_one_line
    line_offset = offset_lookup[filename][line_num]
KeyError: '/github/workspace/foo/bar/../baz.h'
```

This happens because the path gets turned into an absolute path with `os.path.abspath` in `make_file_offset_lookup()` before being used as a key, but in `replace_one_line`, the file path is used verbatim as a key.

To fix this, we convert all replacement FilePaths to absolute paths in `collate_replacement_sets()` before doing anything else with them. 