### PR TITLE
Pass `--max-comments` to Docker with non-split workflow too

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -80,5 +80,6 @@ runs:
     - --exclude='${{ inputs.exclude }}'
     - --apt-packages=${{ inputs.apt_packages }}
     - --cmake-command='${{ inputs.cmake_command }}'
+    - --max-comments=${{ inputs.max_comments }}
     - --lgtm-comment-body='${{ inputs.lgtm_comment_body }}'
     - --split_workflow=${{ inputs.split_workflow }}


### PR DESCRIPTION
Currently, the `--max-comments` arg only gets passed to Docker with the split workflow; with the non-split workflow, the `max_comments` action input is effectively ignored.