### PR TITLE
Automatically find `.clang-tidy`; add collapsible section for notes; automatically download artefacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
 
     # Optionally generate compile_commands.json
 
-    - uses: ZedThree/clang-tidy-review@v0.10.0
+    - uses: ZedThree/clang-tidy-review@v0.12.0
       id: review
     # If there are any comments, fail the check
     - if: steps.review.outputs.total_comments > 0
@@ -78,12 +78,13 @@ at once, so `clang-tidy-review` will only attempt to post the first
 - `base_dir`: Absolute path to initial working directory
   `GITHUB_WORKSPACE`.
   - default: `GITHUB_WORKSPACE`
-- `clang_tidy_version`: Version of clang-tidy to use; one of 6.0, 7, 8, 9, 10, 11
-  - default: '11'
+- `clang_tidy_version`: Version of clang-tidy to use; one of 11, 12,
+  13, 14
+  - default: '14'
 - `clang_tidy_checks`: List of checks
   - default: `'-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*'`
-- `config_file`: Path to clang-tidy config file, replaces `clang_tidy_checks`. Example for a .clang-tidy file at the root of the repo: `config_file: '.clang-tidy'`
-  - default: ''
+- `config_file`: Path to clang-tidy config file, replaces `clang_tidy_checks`
+  - default: `.clang-tidy` if it already exists, otherwise ''
 - `include`: Comma-separated list of files or patterns to include
   - default: `"*.[ch],*.[ch]xx,*.[ch]pp,*.[ch]++,*.cc,*.hh"`
 - `exclude`: Comma-separated list of files or patterns to exclude
@@ -96,9 +97,12 @@ at once, so `clang-tidy-review` will only attempt to post the first
   - default: ''
 - `max_comments`: Maximum number of comments to post at once
   - default: '25'
-- `lgtm_comment_body`: Message to post on PR if no issues are found. An empty string will post no LGTM comment.
+- `lgtm_comment_body`: Message to post on PR if no issues are
+  found. An empty string will post no LGTM comment.
   - default: 'clang-tidy review says "All clean, LGTM! :+1:"'
-- `split_workflow`: Only generate but don't post the review, leaving it for the second workflow. Relevant when receiving PRs from forks that don't have the required permissions to post reviews.
+- `split_workflow`: Only generate but don't post the review, leaving
+  it for the second workflow. Relevant when receiving PRs from forks
+  that don't have the required permissions to post reviews.
   - default: false
 
 ## Outputs
@@ -128,7 +132,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: ZedThree/clang-tidy-review@v0.10.0
+    - uses: ZedThree/clang-tidy-review@v0.12.0
       id: review
       with:
         # List of packages to install
@@ -181,7 +185,7 @@ jobs:
     - name: Set base_dir
       run: echo "base_dir=$(pwd)" >> $GITHUB_ENV
 
-    - uses: ZedThree/clang-tidy-review@v0.10.0
+    - uses: ZedThree/clang-tidy-review@v0.12.0
       id: review
       with:
         # Tell clang-tidy-review the base directory.
@@ -211,7 +215,7 @@ jobs:
 
     # Optionally generate compile_commands.json
 
-    - uses: ZedThree/clang-tidy-review@v0.10.0
+    - uses: ZedThree/clang-tidy-review@v0.12.0
       with:
         split_workflow: true
 
@@ -264,7 +268,7 @@ jobs:
       - name: 'Unzip artifact'
         run: unzip clang-tidy-review.zip
 
-      - uses: ZedThree/clang-tidy-review/post@v0.10.0
+      - uses: ZedThree/clang-tidy-review/post@v0.12.0
 ```
 
 The lint workflow runs with limited permissions, while the post

--- a/post/action.yml
+++ b/post/action.yml
@@ -19,6 +19,12 @@ inputs:
     description: 'Message to post on PR if no issues are found. An empty string will post no LGTM comment.'
     required: false
     default: 'clang-tidy review says "All clean, LGTM! :+1:"'
+  workflow_id:
+    description: 'ID of the review workflow'
+    default: ${{ github.event.workflow_run.id }}
+  pr_number:
+    description: 'PR number of the review workflow'
+    default: ${{ github.event.workflow_run.pull_requests[0].number }}
 outputs:
   total_comments:
     description: 'Total number of warnings from clang-tidy'
@@ -30,3 +36,5 @@ runs:
     - --repo=${{ inputs.repo }}
     - --max-comments=${{ inputs.max_comments }}
     - --lgtm-comment-body='${{ inputs.lgtm_comment_body }}'
+    - --workflow_id=${{ inputs.workflow_id }}
+    - --pr_number=${{ inputs.pr_number }}

--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -147,6 +147,9 @@ class PullRequest:
         self.pr_number = pr_number
         self.token = token
 
+        # Choose API URL, default to public GitHub
+        self.api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+
         github = Github(token)
         repo_object = github.get_repo(f"{repo}")
         self._pull_request = repo_object.get_pull(pr_number)
@@ -159,9 +162,7 @@ class PullRequest:
 
     @property
     def base_url(self):
-        # read the API url from the environment variable GITHUB_API_URL, if it is not set, use the default value
-        api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com")
-        return f"{api_url}/repos/{self.repo}/pulls/{self.pr_number}"
+        return f"{self.api_url}/repos/{self.repo_name}/pulls/{self.pr_number}"
 
     def get(self, media_type: str, extra: str = "") -> str:
         url = f"{self.base_url}{extra}"

--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -781,8 +781,12 @@ def create_review(
         return review
 
 
-def load_metadata() -> Metadata:
+def load_metadata() -> Optional[Metadata]:
     """Load metadata from the METADATA_FILE path"""
+
+    if not pathlib.Path(METADATA_FILE).exists():
+        print(f"\n\nWARNING: Could not find metadata file ('{METADATA_FILE}'), ")
+        return None
 
     with open(METADATA_FILE, "r") as metadata_file:
         return json.load(metadata_file)
@@ -803,12 +807,13 @@ def load_review() -> Optional[PRReview]:
 
     """
 
+    if not pathlib.Path(REVIEW_FILE).exists():
+        print(f"\n\nWARNING: Could not find review file ('{REVIEW_FILE}'), ")
+        return None
+
     with open(REVIEW_FILE, "r") as review_file:
         payload = json.load(review_file)
-        if payload:
-            return payload
-
-        return None
+        return payload or None
 
 
 def get_line_ranges(diff, files):

--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -583,6 +583,9 @@ def format_notes(notes, offset_lookup):
         code = format_ordinary_line(source_line, line_offset)
         code_blocks += f"{message}\n{code}"
 
+    if notes:
+        code_blocks = f"<details>\n<summary>Additional context</summary>\n\n{code_blocks}\n</details>\n"
+
     return code_blocks
 
 

--- a/upload/action.yml
+++ b/upload/action.yml
@@ -1,0 +1,16 @@
+name: 'clang-tidy review - upload artefacts'
+author: 'Peter Hill'
+description: 'Upload artefacts created from a clang-tidy-review run'
+branding:
+  icon: 'book-open'
+  color: 'red'
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/upload-artifact@v3
+      with:
+        name: clang-tidy-review
+        path: |
+          clang-tidy-review-output.json
+          clang-tidy-review-metadata.json
+          clang_fixes.json


### PR DESCRIPTION
Adds a few small features:

- Try to automatically find a `.clang-tidy` file
- Make `--config_file` work with clang-tidy < 12
- Hide long notes in a collapsible section
- Add `upload` action to make uploading files a bit easier
- Automatically download artefacts from `review` Action in `post` Action

Closes #29
Closes #42 
Closes #55 
Closes #59 
Closes #61 
