### PR TITLE
Add experimental support for annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ at once, so `clang-tidy-review` will only attempt to post the first
   it for the second workflow. Relevant when receiving PRs from forks
   that don't have the required permissions to post reviews.
   - default: false
+- `annotations`: Use Annotations instead of comments. A maximum of 10
+  annotations can be written fully, the rest will be summarised. This is a
+  limitation of the GitHub API.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,10 @@ inputs:
     description: "Only generate but don't post the review, leaving it for the second workflow. Relevant when receiving PRs from forks that don't have the required permissions to post reviews."
     required: false
     default: false
+  annotations:
+    description: "Use annotations instead of comments. See README for limitations on annotations"
+    required: false
+    default: false
   pr:
     default: ${{ github.event.pull_request.number }}
   repo:
@@ -83,3 +87,4 @@ runs:
     - --max-comments=${{ inputs.max_comments }}
     - --lgtm-comment-body='${{ inputs.lgtm_comment_body }}'
     - --split_workflow=${{ inputs.split_workflow }}
+    - --annotations=${{ inputs.annotations }}

--- a/post/action.yml
+++ b/post/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'Message to post on PR if no issues are found. An empty string will post no LGTM comment.'
     required: false
     default: 'clang-tidy review says "All clean, LGTM! :+1:"'
+  annotations:
+    description: "Use annotations instead of comments. See README for limitations on annotations"
+    required: false
+    default: false
   workflow_id:
     description: 'ID of the review workflow'
     default: ${{ github.event.workflow_run.id }}
@@ -38,3 +42,4 @@ runs:
     - --lgtm-comment-body='${{ inputs.lgtm_comment_body }}'
     - --workflow_id=${{ inputs.workflow_id }}
     - --pr_number=${{ inputs.pr_number }}
+    - --annotations=${{ inputs.annotations }}

--- a/post/clang_tidy_review/clang_tidy_review/post.py
+++ b/post/clang_tidy_review/clang_tidy_review/post.py
@@ -15,6 +15,8 @@ from clang_tidy_review import (
     load_metadata,
     strip_enclosing_quotes,
     download_artifacts,
+    post_annotations,
+    bool_argument,
 )
 
 
@@ -44,6 +46,12 @@ def main():
         "--workflow_id",
         help="ID of the workflow that generated the review",
         default=None,
+    )
+    parser.add_argument(
+        "--annotations",
+        help="Use annotations instead of comments",
+        type=bool_argument,
+        default=False,
     )
     parser.add_argument("--pr_number", help="PR number", default=None)
 
@@ -78,10 +86,13 @@ def main():
         flush=True,
     )
 
-    lgtm_comment_body = strip_enclosing_quotes(args.lgtm_comment_body)
-    post_review(
-        pull_request, review, args.max_comments, lgtm_comment_body, args.dry_run
-    )
+    if args.annotations:
+        post_annotations(pull_request, review)
+    else:
+        lgtm_comment_body = strip_enclosing_quotes(args.lgtm_comment_body)
+        post_review(
+            pull_request, review, args.max_comments, lgtm_comment_body, args.dry_run
+        )
 
 
 if __name__ == "__main__":

--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -18,6 +18,8 @@ from clang_tidy_review import (
     post_review,
     save_metadata,
     strip_enclosing_quotes,
+    post_annotations,
+    bool_argument,
 )
 
 
@@ -76,15 +78,6 @@ def main():
         type=str,
         default="",
     )
-
-    def bool_argument(user_input):
-        user_input = str(user_input).upper()
-        if user_input == "TRUE":
-            return True
-        if user_input == "FALSE":
-            return False
-        raise ValueError("Invalid value passed to bool_argument")
-
     parser.add_argument(
         "--max-comments",
         help="Maximum number of comments to post at once",
@@ -103,6 +96,12 @@ def main():
             "Only generate but don't post the review, leaving it for the second workflow. "
             "Relevant when receiving PRs from forks that don't have the required permissions to post reviews."
         ),
+        type=bool_argument,
+        default=False,
+    )
+    parser.add_argument(
+        "--annotations",
+        help="Use annotations instead of comments",
         type=bool_argument,
         default=False,
     )
@@ -158,6 +157,10 @@ def main():
 
     if args.split_workflow:
         print("split_workflow is enabled, not posting review")
+        return
+
+    if args.annotations:
+        post_annotations(pull_request, review)
     else:
         lgtm_comment_body = strip_enclosing_quotes(args.lgtm_comment_body)
         post_review(


### PR DESCRIPTION
Closes #51 

This is a pretty rough and ready implementation. Annotations don't support markdown, so they don't look great as I've just converted the comments straight to annotations. Using a different formatter might make them look nicer.

Also, the column isn't reported, but that could be solved with a different formatter.

Currently, if there are any issues, the status is set to `neutral`, but maybe it should be `failed`, or have a user setting to choose which one (`error_on_warnings`?).

I'm going to release this in v0.12 now, as I won't have much time to improve this for a while. PRs to make this feature better are more than welcome!
