### PR TITLE
Don't copy .git directory into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt update && \
     python3-pip \
     && rm -rf /var/lib/apt/lists/
 
-COPY . .git /clang_tidy_review/
+COPY . /clang_tidy_review/
 
 RUN python3 -m pip install --upgrade pip && \
     python3 -m pip install /clang_tidy_review/post/clang_tidy_review


### PR DESCRIPTION
It seems that GitHub doesn't copy the git directory into the runner

Fixes #72