### PR TITLE
Trim trailing spaces around package names

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -121,6 +121,7 @@ def main():
         apt_packages = re.split(BAD_CHARS_APT_PACKAGES_PATTERN, args.apt_packages)[
             0
         ].split(",")
+        apt_packages = [pkg.strip() for pkg in apt_packages]
         with message_group(f"Installing additional packages: {apt_packages}"):
             subprocess.run(["apt-get", "update"])
             subprocess.run(


### PR DESCRIPTION
Given input like so:

```
apt_packages: 'gettext, pkg-config, libzip-dev, libglu1-mesa-dev, libpulse-dev'
```

Installing packages didn't quite work:

```
Installing additional packages: ['gettext', ' pkg-config', ' libzip-dev', ' libglu1-mesa-dev', ' libpulse-dev']
  Get:1 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]
  Get:2 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
  Get:3 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [906 kB]
  Get:4 http://security.ubuntu.com/ubuntu jammy-security/multiverse amd64 Packages [23.2 kB]
  Get:5 http://security.ubuntu.com/ubuntu jammy-security/restricted amd64 Packages [836 kB]
  Get:6 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [869 kB]
  Get:7 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]
  Get:8 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [107 kB]
  Get:9 http://archive.ubuntu.com/ubuntu jammy/universe amd64 Packages [17.5 MB]
  Get:10 http://archive.ubuntu.com/ubuntu jammy/restricted amd64 Packages [164 kB]
  Get:11 http://archive.ubuntu.com/ubuntu jammy/multiverse amd64 Packages [266 kB]
  Get:12 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages [1792 kB]
  Get:13 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [1200 kB]
  Get:14 http://archive.ubuntu.com/ubuntu jammy-updates/multiverse amd64 Packages [28.6 kB]
  Get:15 http://archive.ubuntu.com/ubuntu jammy-updates/restricted amd64 Packages [885 kB]
  Get:16 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1145 kB]
  Get:17 http://archive.ubuntu.com/ubuntu jammy-backports/main amd64 Packages [49.0 kB]
  Get:18 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [22.5 kB]
  Fetched 26.3 MB in 3s (7590 kB/s)
  Reading package lists...
  Reading package lists...
  Building dependency tree...
  Reading state information...
  E: Unable to locate package  pkg-config
  E: Unable to locate package  libzip-dev
  E: Unable to locate package  libglu1-mesa-dev
  E: Unable to locate package  libpulse-dev
```

This should fix it. I'm not a Python coder, ChatGPT wrote this, but it passes the smell test.