### PR TITLE
Always use PR number for split post workflow from uploaded metadata

### DIFF
--- a/post/action.yml
+++ b/post/action.yml
@@ -26,9 +26,6 @@ inputs:
   workflow_id:
     description: 'ID of the review workflow'
     default: ${{ github.event.workflow_run.id }}
-  pr_number:
-    description: 'PR number of the review workflow'
-    default: ${{ github.event.workflow_run.pull_requests[0].number }}
 outputs:
   total_comments:
     description: 'Total number of warnings from clang-tidy'
@@ -41,5 +38,4 @@ runs:
     - --max-comments=${{ inputs.max_comments }}
     - --lgtm-comment-body='${{ inputs.lgtm_comment_body }}'
     - --workflow_id=${{ inputs.workflow_id }}
-    - --pr_number=${{ inputs.pr_number }}
     - --annotations=${{ inputs.annotations }}

--- a/post/clang_tidy_review/clang_tidy_review/post.py
+++ b/post/clang_tidy_review/clang_tidy_review/post.py
@@ -53,11 +53,10 @@ def main():
         type=bool_argument,
         default=False,
     )
-    parser.add_argument("--pr_number", help="PR number", default=None)
 
     args = parser.parse_args()
 
-    pull_request = PullRequest(args.repo, args.pr_number, args.token)
+    pull_request = PullRequest(args.repo, None, args.token)
 
     # Try to read the review artifacts if they're already present
     metadata = load_metadata()
@@ -71,14 +70,7 @@ def main():
     if metadata is None:
         raise RuntimeError("Couldn't find review metadata")
 
-    if args.pr_number is not None and int(args.pr_number) != int(metadata["pr_number"]):
-        raise RuntimeError(
-            f"Conflicting PR numbers: Action was passed #{args.pr_number} "
-            f"and metadata from previous run has #{metadata['pr_number']}"
-        )
-
-    if args.pr_number is None:
-        pull_request.pr_number = metadata["pr_number"]
+    pull_request.pr_number = metadata["pr_number"]
 
     print(
         "clang-tidy-review generated the following review",


### PR DESCRIPTION
Fixes #82

For some reason the event payload (sometimes?) has an empty array of `pull_requests`, but due to the way the Action is set up this passes an empty string to the input `pr_number`. This  causes an error when trying to convert to `int` to compare to the PR number in the metadata.