### PR TITLE
Check exit-code of `apt` invocations

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -123,9 +123,10 @@ def main():
         ].split(",")
         apt_packages = [pkg.strip() for pkg in apt_packages]
         with message_group(f"Installing additional packages: {apt_packages}"):
-            subprocess.run(["apt-get", "update"])
+            subprocess.run(["apt-get", "update"], check=True)
             subprocess.run(
-                ["apt-get", "install", "-y", "--no-install-recommends"] + apt_packages
+                ["apt-get", "install", "-y", "--no-install-recommends"] + apt_packages,
+                check=True,
             )
 
     build_compile_commands = f"{args.build_dir}/compile_commands.json"


### PR DESCRIPTION
When attempting to install packages that don't exist, the `apt-get install` invocation would exit with an error, but the script would continue. This isn't the desired behavior - the action should stop with an error.

This PR fixes that.