### PR TITLE
Upgrade pyyaml to 6.0.1 to fix docker build

### DIFF
--- a/post/clang_tidy_review/pyproject.toml
+++ b/post/clang_tidy_review/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "PyGithub ~= 1.51",
     "unidiff ~= 0.6.0",
     "requests ~= 2.23",
-    "pyyaml ~= 5.4",
+    "pyyaml ~= 6.0.1",
 ]
 keywords = ["C++", "static-analysis"]
 dynamic = ["version"]


### PR DESCRIPTION
Relevant github discussion: https://github.com/yaml/pyyaml/issues/601
An example of build failure: https://github.com/vgvassilev/clad/actions/runs/5629104148/job/15253694275