### PR TITLE
Set total_comments output if split_workflow is true

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -20,6 +20,7 @@ from clang_tidy_review import (
     strip_enclosing_quotes,
     post_annotations,
     bool_argument,
+    set_output,
 )
 
 
@@ -158,6 +159,8 @@ def main():
         save_metadata(args.pr)
 
     if args.split_workflow:
+        total_comments = 0 if review is None else len(review["comments"])
+        set_output("total_comments", total_comments)
         print("split_workflow is enabled, not posting review")
         return
 


### PR DESCRIPTION
Allows to set up the workflow to fail during the review stage instead of posting stage if there are comments.