### PR TITLE
Add base_url param to github object creation

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -154,7 +154,7 @@ class PullRequest:
         # Choose API URL, default to public GitHub
         self.api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com")
 
-        github = Github(token)
+        github = Github(token, base_url=self.api_url)
         self.repo = github.get_repo(f"{repo}")
         self._pull_request = None
 

--- a/post/clang_tidy_review/pyproject.toml
+++ b/post/clang_tidy_review/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 authors = [{name = "Peter Hill", email = "peter.hill@york.ac.uk"}]
 license = {text = "MIT"}
 dependencies = [
-    "PyGithub ~= 1.51",
+    "PyGithub ~= 1.59",
     "unidiff ~= 0.6.0",
     "requests ~= 2.23",
     "pyyaml ~= 6.0.1",


### PR DESCRIPTION
Since 1.58 of PyGithub, it is required to set the base_url to the address of a github entreprise for it to work.

The version lock is loose enough that today it picks up 1.59 which requires this.