### PR TITLE
Add clang-tidy 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,20 @@
-FROM ubuntu:22.04
+FROM ubuntu:23.04
 
 RUN apt update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends\
     build-essential cmake git \
     tzdata \
-    clang-tidy-11 \
-    clang-tidy-12 \
     clang-tidy-13 \
     clang-tidy-14 \
     clang-tidy-15 \
+    clang-tidy-16 \
     python3 \
     python3-pip \
     && rm -rf /var/lib/apt/lists/
 
 COPY . /clang_tidy_review/
 
-RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install /clang_tidy_review/post/clang_tidy_review
+RUN python3 -m pip install --break-system-packages /clang_tidy_review/post/clang_tidy_review
 
 ENTRYPOINT ["review"]

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ at once, so `clang-tidy-review` will only attempt to post the first
 - `base_dir`: Absolute path to initial working directory
   `GITHUB_WORKSPACE`.
   - default: `GITHUB_WORKSPACE`
-- `clang_tidy_version`: Version of clang-tidy to use; one of 11, 12,
-  13, 14, 15
-  - default: '15'
+- `clang_tidy_version`: Version of clang-tidy to use; one of
+  13, 14, 15, 16
+  - default: '16'
 - `clang_tidy_checks`: List of checks
   - default: `'-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*'`
 - `config_file`: Path to clang-tidy config file, replaces `clang_tidy_checks`

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,8 @@ inputs:
     default: ${{ github.workspace }}
     require: false
   clang_tidy_version:
-    description: 'Version of clang-tidy to use; one of 11, 12, 13, 14, 15'
-    default: '15'
+    description: 'Version of clang-tidy to use; one of 13, 14, 15, 16'
+    default: '16'
     required: false
   clang_tidy_checks:
     description: 'List of checks'


### PR DESCRIPTION
Switch to ubuntu lunar.
Versions 11 and 12 are not available.
In this version, installing pip packages outside of a venv are disabled by default.

Fixes  #88