### PR TITLE
Add support for clang-tidy-17 and cmake 3.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,34 @@
 FROM ubuntu:23.04
 
-RUN apt update && \
-    DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y --no-install-recommends\
-    build-essential cmake git \
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update -y && \
+    apt upgrade -y && \
+    apt install -y --no-install-recommends \
+    build-essential \
+    git \
+    ca-certificates \
+    gpg \
+    wget && \
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
+    echo 'deb http://apt.llvm.org/lunar/ llvm-toolchain-lunar-17 main' >> /etc/apt/sources.list && \
+    echo 'deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main' >> /etc/apt/sources.list && \
+    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
+    apt update -y && \
+    rm /usr/share/keyrings/kitware-archive-keyring.gpg && \
+    apt install -y --no-install-recommends \
+    kitware-archive-keyring \
+    cmake \
     tzdata \
     clang-tidy-13 \
     clang-tidy-14 \
     clang-tidy-15 \
     clang-tidy-16 \
+    clang-tidy-17 \
     python3 \
-    python3-pip \
-    && rm -rf /var/lib/apt/lists/
+    python3-pip && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY . /clang_tidy_review/
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ at once, so `clang-tidy-review` will only attempt to post the first
   `GITHUB_WORKSPACE`.
   - default: `GITHUB_WORKSPACE`
 - `clang_tidy_version`: Version of clang-tidy to use; one of
-  13, 14, 15, 16
-  - default: '16'
+  13, 14, 15, 16, 17
+  - default: '17'
 - `clang_tidy_checks`: List of checks
   - default: `'-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*'`
 - `config_file`: Path to clang-tidy config file, replaces `clang_tidy_checks`

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,8 @@ inputs:
     default: ${{ github.workspace }}
     require: false
   clang_tidy_version:
-    description: 'Version of clang-tidy to use; one of 13, 14, 15, 16'
-    default: '16'
+    description: 'Version of clang-tidy to use; one of 13, 14, 15, 16, 17'
+    default: '17'
     required: false
   clang_tidy_checks:
     description: 'List of checks'


### PR DESCRIPTION
@ZedThree Hi, I thought I could add support for `clang-tidy-17` by adding the official LLVM repository to `apt` and do the same with `cmake` by adding its official repository.
My solution mostly follows the official instructions, but is slightly adopted for Docker. See [LLVM](https://apt.llvm.org/) and [Kitware](https://apt.kitware.com/) respectively.