### PR TITLE
Fix Recursive source clang-tidy

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -70,15 +70,20 @@ def build_clang_tidy_warnings(
 
     config = config_file_or_checks(clang_tidy_binary, clang_tidy_checks, config_file)
 
-    print(f"Using config: {config}")
-
     args = [
         clang_tidy_binary,
         f"-p={build_dir}",
-        config,
         f"-line-filter={line_filter}",
         f"--export-fixes={FIXES_FILE}",
-    ] + files
+    ]
+
+    if config:
+        print(f"Using config: {config}")
+        args.append(config)
+    else:
+        print("Using recursive directory config")
+
+    args += files
 
     start = datetime.datetime.now()
     try:
@@ -116,13 +121,13 @@ def clang_tidy_version(clang_tidy_binary: pathlib.Path):
 
 def config_file_or_checks(
     clang_tidy_binary: pathlib.Path, clang_tidy_checks: str, config_file: str
-):
+) -> Optional[str]:
     version = clang_tidy_version(clang_tidy_binary)
 
     if config_file == "":
         if clang_tidy_checks:
             return f"--checks={clang_tidy_checks}"
-        return ""
+        return None
 
     if version >= 12:
         return f"--config-file={config_file}"

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -414,7 +414,7 @@ def test_config_file(monkeypatch, tmp_path):
     flag = ctr.config_file_or_checks(
         "not-clang-tidy", clang_tidy_checks="", config_file=""
     )
-    assert flag == f""
+    assert flag is None
 
     # If you get config_file to something, config_file is sent to clang-tidy.
     flag = ctr.config_file_or_checks(


### PR DESCRIPTION
There's an issue when trying to run clang-tidy without `--checks` and `--config-file`.
This is the case when you want to use the `.clang-tidy` configs in a recursive per-directory way.

In #96, I added the ability to set both checks and config to empty strings which did this, however, switching to `shell=False`, means that empty strings still count as arguments.

This ends up with `''` being sent to clang-tidy as an agument which clang-tidy interprets as a file name (`$PWD + ''` to check. It then emits and error that the current directory cannot be opened.

This PR makes sure that in this case, the `''` argument is not set and prints a more useful message in that case.