### PR TITLE
Fix split workflow when no comments can be posted

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -895,7 +895,7 @@ def load_and_merge_reviews(review_files: List[pathlib.Path]) -> Optional[PRRevie
     reviews = []
     for file in review_files:
         review = load_review(file)
-        if review is not None:
+        if review is not None and len(review.get("comments", [])) > 0:
             reviews.append(review)
 
     if not reviews:

--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -764,14 +764,32 @@ def create_review(
     files = filter_files(diff, include, exclude)
 
     if files == []:
-        print("No files to check!")
+        with message_group("No files to check!"):
+            with open(REVIEW_FILE, "w") as review_file:
+                json.dump(
+                    {
+                        "body": "clang-tidy found no files to check",
+                        "event": "COMMENT",
+                        "comments": [],
+                    },
+                    review_file,
+                )
         return None
 
     print(f"Checking these files: {files}", flush=True)
 
     line_ranges = get_line_ranges(diff, files)
     if line_ranges == "[]":
-        print("No lines added in this PR!")
+        with message_group("No lines added in this PR!"):
+            with open(REVIEW_FILE, "w") as review_file:
+                json.dump(
+                    {
+                        "body": "clang-tidy found no lines added",
+                        "event": "COMMENT",
+                        "comments": [],
+                    },
+                    review_file,
+                )
         return None
 
     print(f"Line filter for clang-tidy:\n{line_ranges}\n")


### PR DESCRIPTION
There is an edge case in split workflow where the `review` does not create
a `clang-tidy-review-output.json` but the rest of the workflow expects the
file to be created even if there are no comments.
    
This causes `cp` or `mv` operations to fail and the `post` portion of the
workflow fails trying to open an expected file.
    
This change makes sure the output is created even if there is nothing to
report. The body also serves to debug why there are no comments.