### PR TITLE
Bump PyGithub to 2.1

### DIFF
--- a/post/clang_tidy_review/pyproject.toml
+++ b/post/clang_tidy_review/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 authors = [{name = "Peter Hill", email = "peter.hill@york.ac.uk"}]
 license = {text = "MIT"}
 dependencies = [
-    "PyGithub ~= 1.59",
+    "PyGithub ~= 2.1",
     "unidiff ~= 0.6.0",
     "requests ~= 2.23",
     "pyyaml ~= 6.0.1",


### PR DESCRIPTION
This fixes issues on build servers who have ~/.netrc that interfere with token authentication.

Prior versions would silently ignore the token and use what is in netrc instead. This was fixed in [2.1](https://github.com/PyGithub/PyGithub/releases#reactions--reaction_button_component-63ef49)