### PR TITLE
Fix line filter on for clang compiler on windows

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -948,9 +948,14 @@ def get_line_ranges(diff, files):
 
     line_filter_json = []
     for name, lines in lines_by_file.items():
-        # On windows, unidiff has forward slashes but clang-tidy expects backslashes
-        name = os.path.join(*name.split("/"))
         line_filter_json.append({"name": name, "lines": lines})
+        # On windows, unidiff has forward slashes but cl.exe expects backslashes.
+        # However, clang.exe on windows expects forward slashes.
+        # Adding a copy of the line filters with backslashes allows for both cl.exe and clang.exe to work.
+        if os.path.sep == "\\":
+            # Converts name to backslashes for the cl.exe line filter.
+            name = os.path.join(*name.split("/"))
+            line_filter_json.append({"name": name, "lines": lines})
     return json.dumps(line_filter_json, separators=(",", ":"))
 
 


### PR DESCRIPTION
The line filters seem to be sensitive to the compiler used. When using MSVC, the line filter must use backslashes in the name. However, if the clang compiler is used on Windows, it must be forward.

The simplest solution to this issue is to use an extra entry of the line filter one with forward slashes and one without.
This allows all compilers to be happy regardless of OS and without looking at compilation databases.