### PR TITLE
Fix default `REVIEW_FILES` in split workflow post

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/post.py
+++ b/post/clang_tidy_review/clang_tidy_review/post.py
@@ -60,7 +60,7 @@ def main() -> int:
         metavar="REVIEW_FILES",
         type=pathlib.Path,
         nargs="*",
-        default=[REVIEW_FILE],
+        default=[pathlib.Path(REVIEW_FILE)],
         help="Split workflow review results",
     )
 


### PR DESCRIPTION
The default value was left a string when they were converted to `pathlib.Path` this causes a `AttributeError: 'str' object has no attribute 'exists'`