### PR TITLE
Don't override original env variables

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -90,7 +90,7 @@ def build_clang_tidy_warnings(
     try:
         with message_group(f"Running:\n\t{args}"):
             env = dict(os.environ)
-            env['USER'] = username
+            env["USER"] = username
             subprocess.run(
                 args,
                 capture_output=True,

--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -89,12 +89,14 @@ def build_clang_tidy_warnings(
     start = datetime.datetime.now()
     try:
         with message_group(f"Running:\n\t{args}"):
+            env = dict(os.environ)
+            env['USER'] = username
             subprocess.run(
                 args,
                 capture_output=True,
                 check=True,
                 encoding="utf-8",
-                env={"USER": username},
+                env=env,
             )
     except subprocess.CalledProcessError as e:
         print(


### PR DESCRIPTION
Setting `{"USER": username}` as env causes custom env values to be hidden.
This is an issue when using `PATH` to locate clang-tidy