### PR TITLE
Use PyGithub to reuse auth headers to do requests

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -60,6 +60,44 @@ class PRReview(TypedDict):
     comments: List[PRReviewComment]
 
 
+class HashableComment:
+    def __init__(self, body: str, line: int, path: str, side: str, **kwargs):
+        self.body = body
+        self.line = line
+        self.path = path
+        self.side = side
+
+    def __hash__(self):
+        return hash(
+            (
+                self.body,
+                self.line,
+                self.path,
+                self.side,
+            )
+        )
+
+    def __eq__(self, other):
+        return (
+            type(self) is type(other)
+            and self.body == other.body
+            and self.line == self.line
+            and other.path == other.path
+            and self.side == other.side
+        )
+
+    def __lt__(self, other):
+        if self.path != other.path:
+            return self.path < other.path
+        if self.line != other.line:
+            return self.line < other.line
+        if self.side != other.side:
+            return self.side < other.side
+        if self.body != other.body:
+            return self.body < other.body
+        return id(self) < id(other)
+
+
 def add_auth_arguments(parser: argparse.ArgumentParser):
     # Token
     parser.add_argument("--token", help="github auth token")
@@ -952,39 +990,11 @@ def load_and_merge_reviews(review_files: List[pathlib.Path]) -> Optional[PRRevie
 
     result = reviews[0]
 
-    class Comment:
-        def __init__(self, data):
-            self.data = data
-
-        def __hash__(self):
-            return hash(
-                (
-                    self.data["body"],
-                    self.data["line"],
-                    self.data["path"],
-                    self.data["side"],
-                )
-            )
-
-        def __eq__(self, other):
-            return type(other) is Comment and self.data == other.data
-
-        def __lt__(self, other):
-            if self.data["path"] != other.data["path"]:
-                return self.data["path"] < other.data["path"]
-            if self.data["line"] != other.data["line"]:
-                return self.data["line"] < other.data["line"]
-            if self.data["side"] != other.data["side"]:
-                return self.data["side"] < other.data["side"]
-            if self.data["body"] != other.data["body"]:
-                return self.data["body"] < other.data["body"]
-            return hash(self) < hash(other)
-
     comments = set()
     for review in reviews:
-        comments.update(map(Comment, review["comments"]))
+        comments.update(map(lambda c: HashableComment(**c), review["comments"]))
 
-    result["comments"] = [c.data for c in sorted(comments)]
+    result["comments"] = [c.__dict__ for c in sorted(comments)]
 
     return result
 
@@ -1032,19 +1042,14 @@ def cull_comments(pull_request: PullRequest, review, max_comments):
 
     """
 
-    comments = pull_request.get_pr_comments()
+    unposted_comments = set(map(lambda c: HashableComment(**c), review["comments"]))
+    posted_comments = set(
+        map(lambda c: HashableComment(**c), pull_request.get_pr_comments())
+    )
 
-    for comment in comments:
-        review["comments"] = list(
-            filter(
-                lambda review_comment: not (
-                    review_comment["path"] == comment["path"]
-                    and review_comment["line"] == comment["line"]
-                    and review_comment["body"] == comment["body"]
-                ),
-                review["comments"],
-            )
-        )
+    review["comments"] = [
+        c.__dict__ for c in sorted(unposted_comments - posted_comments)
+    ]
 
     if len(review["comments"]) > max_comments:
         review["body"] += (

--- a/post/clang_tidy_review/pyproject.toml
+++ b/post/clang_tidy_review/pyproject.toml
@@ -15,7 +15,6 @@ license = {text = "MIT"}
 dependencies = [
     "PyGithub ~= 2.1",
     "unidiff ~= 0.6.0",
-    "requests ~= 2.23",
     "pyyaml ~= 6.0.1",
 ]
 keywords = ["C++", "static-analysis"]


### PR DESCRIPTION
Clean-up custom url creation and use PyGithub objects for that.
Use PyGithub checker function to catch 400+ codes.

This fixes app authenticated sessions losing the authentication for requests when downloading diffs and posting reviews.
This fixes `~/.netrc` authentication hijacking the authentication through the requests library.

Re-use the hashable comment class to filter already posted comments