### PR TITLE
fix: download artifacts as binary blobs and follow redirects

### DIFF
--- a/post/clang_tidy_review/pyproject.toml
+++ b/post/clang_tidy_review/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "PyGithub ~= 2.1",
     "unidiff ~= 0.6.0",
     "pyyaml ~= 6.0.1",
+    "urllib3 ~= 2.2.1",
 ]
 keywords = ["C++", "static-analysis"]
 dynamic = ["version"]

--- a/upload/action.yml
+++ b/upload/action.yml
@@ -7,7 +7,7 @@ branding:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: clang-tidy-review
         path: |


### PR DESCRIPTION
I'm sorry for not testing properly in https://github.com/ZedThree/clang-tidy-review/pull/115. The stuff still fails, because pygithub doesn't follow redirects and the artifact is a binary blob, not JSON (I tested it this time).

https://github.com/ZedThree/clang-tidy-review/pull/113 noted that using `requests` isn't nice, so I'm using `urllib3`.
The `accept` header might look weird, but [the documentation recommends this](https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#download-an-artifact) even though we get a zip returned 🙃.

I've also noticed that this action still uses `actions/upload-action@v3` (uses deprecated node version), so I updated it to v4.

While testing, I noticed that the action fails even though it succeeded, because since https://github.com/ZedThree/clang-tidy-review/pull/103, the action exits with the amount of comments. I'd like to open a PR (after this one) that adds an option to disable this.