### PR TITLE
chore: add `num_comments_as_exitcode` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ at once, so `clang-tidy-review` will only attempt to post the first
 - `annotations`: Use Annotations instead of comments. A maximum of 10
   annotations can be written fully, the rest will be summarised. This is a
   limitation of the GitHub API.
+- `num_comments_as_exitcode`: Set the exit code to be the amount of comments (enabled by default).
 
 ## Outputs
 

--- a/post/action.yml
+++ b/post/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: "Use annotations instead of comments. See README for limitations on annotations"
     required: false
     default: false
+  num_comments_as_exitcode:
+    description: "Set the exit code to be the amount of comments"
+    required: false
+    default: 'true'
   workflow_id:
     description: 'ID of the review workflow'
     default: ${{ github.event.workflow_run.id }}
@@ -39,3 +43,4 @@ runs:
     - --lgtm-comment-body='${{ inputs.lgtm_comment_body }}'
     - --workflow_id=${{ inputs.workflow_id }}
     - --annotations=${{ inputs.annotations }}
+    - --num-comments-as-exitcode=${{ inputs.num_comments_as_exitcode }}

--- a/post/clang_tidy_review/clang_tidy_review/post.py
+++ b/post/clang_tidy_review/clang_tidy_review/post.py
@@ -56,6 +56,12 @@ def main() -> int:
         type=bool_argument,
         default=False,
     )
+    parser.add_argument(
+        "--num-comments-as-exitcode",
+        help="Set the exit code to be the amount of comments",
+        type=bool_argument,
+        default=True,
+    )
     add_auth_arguments(parser)
     parser.add_argument(
         "reviews",
@@ -91,12 +97,17 @@ def main() -> int:
     )
 
     if args.annotations:
-        return post_annotations(pull_request, review)
+        exit_code = post_annotations(pull_request, review)
     else:
         lgtm_comment_body = strip_enclosing_quotes(args.lgtm_comment_body)
-        return post_review(
+        exit_code = post_review(
             pull_request, review, args.max_comments, lgtm_comment_body, args.dry_run
         )
+
+    if args.num_comments_as_exitcode:
+        return exit_code
+    else:
+        return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I mentioned this in #118 a bit. Having the exit-code be non-zero will cause the workflow to count as failed, even though it posted the comments successfully, which will notify the user. Using `continue-on-error` isn't ideal for this either, as it will hide errors in this action. On the other hand, I can understand the use-case for this.

I'm adding the `num_comments_as_exitcode` input/option, which, as the name suggests, controls whether the exit-code will be set to the number of comments or 0. It's enabled by default, so nothing should change.