### PR TITLE
Add clang-tidy 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
-FROM ubuntu:23.04
+FROM ubuntu:24.04
 
 RUN apt update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends\
     build-essential cmake git \
     tzdata \
-    clang-tidy-13 \
     clang-tidy-14 \
     clang-tidy-15 \
     clang-tidy-16 \
+    clang-tidy-17 \
+    clang-tidy-18 \
     python3 \
     python3-pip \
     && rm -rf /var/lib/apt/lists/

--- a/README.md
+++ b/README.md
@@ -88,9 +88,8 @@ at once, so `clang-tidy-review` will only attempt to post the first
 - `base_dir`: Absolute path to initial working directory
   `GITHUB_WORKSPACE`.
   - default: `GITHUB_WORKSPACE`
-- `clang_tidy_version`: Version of clang-tidy to use; one of
-  13, 14, 15, 16
-  - default: '16'
+- `clang_tidy_version`: Version of clang-tidy to use; one of 14, 15, 16, 17, 18
+  - default: '18'
 - `clang_tidy_checks`: List of checks
   - default: `'-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*'`
 - `config_file`: Path to clang-tidy config file, replaces `clang_tidy_checks`

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,8 @@ inputs:
     default: ${{ github.workspace }}
     require: false
   clang_tidy_version:
-    description: 'Version of clang-tidy to use; one of 13, 14, 15, 16'
-    default: '16'
+    description: 'Version of clang-tidy to use; one of 14, 15, 16, 17, 18'
+    default: '18'
     required: false
   clang_tidy_checks:
     description: 'List of checks'


### PR DESCRIPTION
Since Ubuntu 24.04 LTS is now available, this adds support for versions 17 and 18 (the latter becoming the default).
It also removes version 13 as it's no longer available in Ubuntu Noble's repos.