### PR TITLE
Use task queue to spawn multiple processes of tidy

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,10 @@ inputs:
     description: "Use annotations instead of comments. See README for limitations on annotations"
     required: false
     default: false
+  parallel:
+    description: "Number of tidy instances to be run in parallel. Zero will automatically determine the right number."
+    required: false
+    default: "0"
   pr:
     default: ${{ github.event.pull_request.number }}
   repo:
@@ -88,3 +92,4 @@ runs:
     - --lgtm-comment-body='${{ inputs.lgtm_comment_body }}'
     - --split_workflow=${{ inputs.split_workflow }}
     - --annotations=${{ inputs.annotations }}
+    - --parallel=${{ inputs.parallel }}

--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -113,6 +113,13 @@ def main():
         default=False,
     )
     parser.add_argument(
+        "-j",
+        "--parallel",
+        help="Number of tidy instances to be run in parallel.",
+        type=int,
+        default=0,
+    )
+    parser.add_argument(
         "--dry-run", help="Run and generate review, but don't post", action="store_true"
     )
     add_auth_arguments(parser)
@@ -157,6 +164,7 @@ def main():
         args.clang_tidy_checks,
         args.clang_tidy_binary,
         args.config_file,
+        args.parallel,
         include,
         exclude,
     )

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,3 +1,5 @@
+import datetime
+
 import clang_tidy_review as ctr
 
 import difflib
@@ -235,10 +237,10 @@ def test_line_ranges():
     assert line_ranges == expected_line_ranges
 
 
-def test_load_clang_tidy_warnings(monkeypatch):
-    monkeypatch.setattr(ctr, "FIXES_FILE", str(TEST_DIR / f"src/test_{ctr.FIXES_FILE}"))
-
-    warnings = ctr.load_clang_tidy_warnings()
+def test_load_clang_tidy_warnings():
+    warnings = ctr.load_clang_tidy_warnings(
+        str(TEST_DIR / f"src/test_{ctr.FIXES_FILE}")
+    )
 
     assert sorted(list(warnings.keys())) == ["Diagnostics", "MainSourceFile"]
     assert warnings["MainSourceFile"] == "/clang_tidy_review/src/hello.cxx"
@@ -470,5 +472,5 @@ def test_timing_summary(monkeypatch):
     assert "time.clang-tidy.total.wall" in profiling["hello.cxx"].keys()
     assert "time.clang-tidy.total.user" in profiling["hello.cxx"].keys()
     assert "time.clang-tidy.total.sys" in profiling["hello.cxx"].keys()
-    summary = ctr.make_timing_summary(profiling)
-    assert len(summary.split("\n")) == 21
+    summary = ctr.make_timing_summary(profiling, datetime.timedelta(seconds=42))
+    assert len(summary.split("\n")) == 22


### PR DESCRIPTION
This PR streamlines `build_clang_tidy_warnings` to be easily dispatched by a multi-process queue. Each process stores the fixes in a temporary directory.
The queue will dispatch a clang-tidy process per file to check. This way more complex files can run at the same time as less complex ones.
Added a function to combine fixes after the queue is done running.

The design is copied from llvm's `run-clang-tidy.py` script and adapted for the current code.

Things I've noticed running this:
* On ubuntu actions, this spawns 4 processes.
* ~~Cancelling a workflow only cancels the running queue processes but will still do the post step.~~
* The logs get spammed. (#128)
* It's hard to tell which log did what.
* A change with 28 files took 17m 45s with 4 processes while upstream took 33m 11s
* The file ranges cover the whole source but each process is a single file.

Depends on:
- [x] #127 

Closes #124 