### PR TITLE
fix: support empty commits/PRs

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -286,7 +286,7 @@ class PullRequest:
             self._pull_request = self.repo.get_pull(int(self.pr_number))
         return self._pull_request
 
-    def get_pr_diff(self) -> List[unidiff.PatchSet]:
+    def get_pr_diff(self) -> List[unidiff.PatchedFile]:
         """Download the PR diff, return a list of PatchedFile"""
 
         _, data = self.repo._requester.requestJsonAndCheck(
@@ -294,6 +294,9 @@ class PullRequest:
             self.pull_request.url,
             headers={"Accept": f"application/vnd.github.{'v3.diff'}"},
         )
+        if not data:
+            return []
+
         diffs = data["data"]
 
         # PatchSet is the easiest way to construct what we want, but the


### PR DESCRIPTION
When opening a PR without any changes (with one or more empty commits), `clang-tidy-review` currently fails with

```
Traceback (most recent call last):
  File "/usr/local/bin/review", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/clang_tidy_review/review.py", line 154, in main
    review = create_review(
             ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/clang_tidy_review/__init__.py", line 843, in create_review
    diff = pull_request.get_pr_diff()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/clang_tidy_review/__init__.py", line 297, in get_pr_diff
    diffs = data["data"]
            ~~~~^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

This PR checks `data` and returns with no changes.

While doing that, I noticed the return-type being wrong in this method, so I fixed that too.