### PR TITLE
Fix remaining Ruff lints and (most) type errors

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -1224,7 +1224,7 @@ def decorate_check_names(comment: str) -> str:
     url = f"https://clang.llvm.org/{version}/clang-tidy/checks"
     regex = r"(\[((?:clang-analyzer)|(?:(?!clang)[\w]+))-([\.\w-]+)\]$)"
     subst = f"[\\g<1>({url}/\\g<2>/\\g<3>.html)]"
-    return re.sub(regex, subst, comment, 1, re.MULTILINE)
+    return re.sub(regex, subst, comment, count=1, flags=re.MULTILINE)
 
 
 def decorate_comment(comment: PRReviewComment) -> PRReviewComment:

--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -929,32 +929,34 @@ def create_review(
     files = filter_files(diff, include, exclude)
 
     if files == []:
-        with message_group("No files to check!"):
-            with Path(REVIEW_FILE).open("w") as review_file:
-                json.dump(
-                    {
-                        "body": "clang-tidy found no files to check",
-                        "event": "COMMENT",
-                        "comments": [],
-                    },
-                    review_file,
-                )
+        with message_group("No files to check!"), Path(REVIEW_FILE).open(
+            "w"
+        ) as review_file:
+            json.dump(
+                {
+                    "body": "clang-tidy found no files to check",
+                    "event": "COMMENT",
+                    "comments": [],
+                },
+                review_file,
+            )
         return None
 
     print(f"Checking these files: {files}", flush=True)
 
     line_ranges = get_line_ranges(diff, files)
     if line_ranges == "[]":
-        with message_group("No lines added in this PR!"):
-            with Path(REVIEW_FILE).open("w") as review_file:
-                json.dump(
-                    {
-                        "body": "clang-tidy found no lines added",
-                        "event": "COMMENT",
-                        "comments": [],
-                    },
-                    review_file,
-                )
+        with message_group("No lines added in this PR!"), Path(REVIEW_FILE).open(
+            "w"
+        ) as review_file:
+            json.dump(
+                {
+                    "body": "clang-tidy found no lines added",
+                    "event": "COMMENT",
+                    "comments": [],
+                },
+                review_file,
+            )
         return None
 
     print(f"Line filter for clang-tidy:\n{line_ranges}\n")

--- a/post/clang_tidy_review/clang_tidy_review/post.py
+++ b/post/clang_tidy_review/clang_tidy_review/post.py
@@ -105,7 +105,7 @@ def main() -> int:
             pull_request, review, args.max_comments, lgtm_comment_body, args.dry_run
         )
 
-    return exit_code if args.num_comments_as_exitcode else 0
+    return (exit_code or 0) if args.num_comments_as_exitcode else 0
 
 
 if __name__ == "__main__":

--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -6,10 +6,9 @@
 # See LICENSE for more information
 
 import argparse
-import os
-import pathlib
 import re
 import subprocess
+from pathlib import Path
 
 from clang_tidy_review import (
     PullRequest,
@@ -39,7 +38,7 @@ def main():
         "--clang_tidy_binary",
         help="clang-tidy binary",
         default="clang-tidy-14",
-        type=pathlib.Path,
+        type=Path,
     )
     parser.add_argument(
         "--build_dir", help="Directory with compile_commands.json", default="."
@@ -145,7 +144,7 @@ def main():
         with message_group(f"Running cmake: {cmake_command}"):
             subprocess.run(cmake_command, shell=True, check=True)
 
-    elif os.path.exists(build_compile_commands):
+    elif Path(build_compile_commands).exists():
         fix_absolute_paths(build_compile_commands, args.base_dir)
 
     pull_request = PullRequest(args.repo, args.pr, get_auth_from_arguments(args))

--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -164,7 +164,7 @@ def main():
 
     if args.split_workflow:
         total_comments = 0 if review is None else len(review["comments"])
-        set_output("total_comments", total_comments)
+        set_output("total_comments", str(total_comments))
         print("split_workflow is enabled, not posting review")
         return
 


### PR DESCRIPTION
As the title says, this fixes the remaining lints from https://github.com/ZedThree/clang-tidy-review/pull/133 (that's the target of the PR) as well as some typing errors (the remaining ones can be fixed in a separate PR). I noticed that `pygithub` now has [`PullRequest.get_comments`](https://pygithub.readthedocs.io/en/stable/github_objects/PullRequest.html#github.PullRequest.PullRequest.get_comments) which we could migrate to. Furthermore, there should probably a ruff check in CI.

Aside: A release would be great. Currently, comments are duplicated (not culled) - this is fixed on master (I think).