### PR TITLE
fix(split-review): search by string in names

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -266,7 +266,7 @@ def merge_replacement_files(tmpdir: Path, mergefile: Path):
             yaml.safe_dump(output, out)
 
 
-def load_clang_tidy_warnings(fixes_file) -> Dict:
+def load_clang_tidy_warnings(fixes_file: Path) -> Dict:
     """Read clang-tidy warnings from fixes_file. Can be produced by build_clang_tidy_warnings"""
     try:
         with fixes_file.open() as f:
@@ -955,9 +955,7 @@ def create_review(
     files = filter_files(diff, include, exclude)
 
     if files == []:
-        with message_group("No files to check!"), Path(REVIEW_FILE).open(
-            "w"
-        ) as review_file:
+        with message_group("No files to check!"), REVIEW_FILE.open("w") as review_file:
             json.dump(
                 {
                     "body": "clang-tidy found no files to check",
@@ -972,7 +970,7 @@ def create_review(
 
     line_ranges = get_line_ranges(diff, files)
     if line_ranges == "[]":
-        with message_group("No lines added in this PR!"), Path(REVIEW_FILE).open(
+        with message_group("No lines added in this PR!"), REVIEW_FILE.open(
             "w"
         ) as review_file:
             json.dump(
@@ -1071,7 +1069,7 @@ def create_review(
         review = create_review_file(
             clang_tidy_warnings, diff_lookup, offset_lookup, build_dir
         )
-        with Path(REVIEW_FILE).open("w") as review_file:
+        with REVIEW_FILE.open("w") as review_file:
             json.dump(review, review_file)
 
         return review
@@ -1125,11 +1123,11 @@ def download_artifacts(pull: PullRequest, workflow_id: int):
 def load_metadata() -> Optional[Metadata]:
     """Load metadata from the METADATA_FILE path"""
 
-    if not pathlib.Path(METADATA_FILE).exists():
+    if not METADATA_FILE.exists():
         print(f"WARNING: Could not find metadata file ('{METADATA_FILE}')", flush=True)
         return None
 
-    with Path(METADATA_FILE).open() as metadata_file:
+    with METADATA_FILE.open() as metadata_file:
         return json.load(metadata_file)
 
 
@@ -1138,7 +1136,7 @@ def save_metadata(pr_number: int) -> None:
 
     metadata: Metadata = {"pr_number": pr_number}
 
-    with Path(METADATA_FILE).open("w") as metadata_file:
+    with METADATA_FILE.open("w") as metadata_file:
         json.dump(metadata, metadata_file)
 
 
@@ -1156,7 +1154,7 @@ def load_review(review_file: pathlib.Path) -> Optional[PRReview]:
 
 def load_and_merge_profiling() -> Dict:
     result = {}
-    for profile_file in Path(PROFILE_DIR).glob("*.json"):
+    for profile_file in PROFILE_DIR.glob("*.json"):
         profile_dict = json.load(profile_file.open())
         filename = profile_dict["file"]
         current_profile = result.get(filename, {})

--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -1111,11 +1111,13 @@ def download_artifacts(pull: PullRequest, workflow_id: int):
 
     metadata = (
         json.loads(data.read(str(METADATA_FILE)))
-        if METADATA_FILE in filenames
+        if str(METADATA_FILE) in filenames
         else None
     )
     review = (
-        json.loads(data.read(str(REVIEW_FILE))) if REVIEW_FILE in filenames else None
+        json.loads(data.read(str(REVIEW_FILE)))
+        if str(REVIEW_FILE) in filenames
+        else None
     )
     return metadata, review
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -11,6 +11,8 @@ import unidiff
 
 import pytest
 
+from pathlib import Path
+
 TEST_DIR = pathlib.Path(__file__).parent
 TEST_FILE = TEST_DIR / "src/hello.cxx"
 TEST_DIFF = [
@@ -191,7 +193,7 @@ def test_fix_absolute_paths(tmp_path):
 
 
 def test_save_load_metadata(tmp_path, monkeypatch):
-    monkeypatch.setattr(ctr, "METADATA_FILE", str(tmp_path / ctr.METADATA_FILE))
+    monkeypatch.setattr(ctr, "METADATA_FILE", tmp_path / ctr.METADATA_FILE)
 
     ctr.save_metadata(42)
     meta = ctr.load_metadata()
@@ -391,7 +393,7 @@ def test_version(monkeypatch):
         lambda *args, **kwargs: MockClangTidyVersionProcess(expected_version),
     )
 
-    version = ctr.clang_tidy_version("not-clang-tidy")
+    version = ctr.clang_tidy_version(Path("not-clang-tidy"))
     assert version == expected_version
 
 
@@ -406,25 +408,27 @@ def test_config_file(monkeypatch, tmp_path):
 
     # If you set clang_tidy_checks to something and config_file to something, config_file is sent to clang-tidy.
     flag = ctr.config_file_or_checks(
-        "not-clang-tidy", clang_tidy_checks="readability", config_file=str(config_file)
+        Path("not-clang-tidy"),
+        clang_tidy_checks="readability",
+        config_file=str(config_file),
     )
     assert flag == f"--config-file={config_file}"
 
     # If you set clang_tidy_checks and config_file to an empty string, neither are sent to the clang-tidy.
     flag = ctr.config_file_or_checks(
-        "not-clang-tidy", clang_tidy_checks="", config_file=""
+        Path("not-clang-tidy"), clang_tidy_checks="", config_file=""
     )
     assert flag is None
 
     # If you get config_file to something, config_file is sent to clang-tidy.
     flag = ctr.config_file_or_checks(
-        "not-clang-tidy", clang_tidy_checks="", config_file=str(config_file)
+        Path("not-clang-tidy"), clang_tidy_checks="", config_file=str(config_file)
     )
     assert flag == f"--config-file={config_file}"
 
     # If you get clang_tidy_checks to something and config_file to nothing, clang_tidy_checks is sent to clang-tidy.
     flag = ctr.config_file_or_checks(
-        "not-clang-tidy", clang_tidy_checks="readability", config_file=""
+        Path("not-clang-tidy"), clang_tidy_checks="readability", config_file=""
     )
     assert flag == "--checks=readability"
 
@@ -465,7 +469,7 @@ def test_decorate_comment_body():
 
 
 def test_timing_summary(monkeypatch):
-    monkeypatch.setattr(ctr, "PROFILE_DIR", str(TEST_DIR / "src/clang-tidy-profile"))
+    monkeypatch.setattr(ctr, "PROFILE_DIR", TEST_DIR / "src/clang-tidy-profile")
     profiling = ctr.load_and_merge_profiling()
     assert "time.clang-tidy.total.wall" in profiling["hello.cxx"].keys()
     assert "time.clang-tidy.total.user" in profiling["hello.cxx"].keys()


### PR DESCRIPTION
Since the review files are `Path`s now, they can't be searched by in `list[str]`s. In particular, the file can't be searched in `ZipFile#namelist()` in `download_artifacts` (example run: https://github.com/Chatterino/chatterino2/actions/runs/11756776343/job/32753285579).

This PR, in particular the first commit, fixes that by converting to a string.

With paths being `Path`s now, many `Path(foo)` can be converted to `foo`. The tests didn't pass `Path`s, so I fixed that too.

I tested the last commit at https://github.com/Nerixyz/test-mini-cpp-project/pull/6.
