### PR TITLE
fix: use pygithub to get PR comments

### DIFF
--- a/post/clang_tidy_review/pyproject.toml
+++ b/post/clang_tidy_review/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 authors = [{name = "Peter Hill", email = "peter.hill@york.ac.uk"}]
 license = {text = "MIT"}
 dependencies = [
-    "PyGithub ~= 2.1",
+    "PyGithub ~= 2.6",
     "unidiff ~= 0.6.0",
     "pyyaml ~= 6.0.1",
     "urllib3 ~= 2.2.1",


### PR DESCRIPTION
When trying to post comments to a PR which already has review comments, the action currently fails ([example](https://github.com/Nerixyz/test-mini-cpp-project/actions/runs/13549744175/job/37870205707)).

Pygithub 2.6.0 updated the `PullRequestComment` class and added the remaining fields we needed, so it should be easier to use `PullRequestComment` directly.

I tested this in https://github.com/Nerixyz/test-mini-cpp-project/pull/10 where I had some additional debug logging for the comments.

One thing I was confused about was that `line`  returns `None` for some review comments. However, `original_line` seems to be populated in that case. 