### PR TITLE
[install_commands] add option to inject install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ some system packages (the different `clang-tidy` versions) as well as
 some Python packages. This that means that there's a two-three minutes
 start-up in order to build the Docker container. If you need to
 install some additional packages you can pass them via the
-`apt_packages` argument.
+`apt_packages` argument or run some install commands with `install_commands`.
 
 Except for very simple projects, a `compile_commands.json` file is necessary for
 clang-tidy to find headers, set preprocessor macros, and so on. You can generate
@@ -99,6 +99,8 @@ at once, so `clang-tidy-review` will only attempt to post the first
 - `exclude`: Comma-separated list of files or patterns to exclude
   - default: ''
 - `apt_packages`: Comma-separated list of apt packages to install
+  - default: ''
+- `install_commands`: Commands to execute after `apt_packages` before `cmake_command`
   - default: ''
 - `cmake_command`: A CMake command to configure your project and generate
   `compile_commands.json` in `build_dir`. You _almost certainly_ want
@@ -149,7 +151,8 @@ jobs:
       id: review
       with:
         # List of packages to install
-        apt_packages: liblapack-dev
+        apt_packages: liblapack-dev,devscripts,equivs
+        install_commands: 'ln -s foo bar; mk-build-deps -i'
         # CMake command to run in order to generate compile_commands.json
         cmake_command: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=on
 ```

--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,7 @@ runs:
     - --include='${{ inputs.include }}'
     - --exclude='${{ inputs.exclude }}'
     - --apt-packages=${{ inputs.apt_packages }}
-    - --install-commands=${{ inputs.install_commands }}
+    - --install-commands='${{ inputs.install_commands }}'
     - --cmake-command='${{ inputs.cmake_command }}'
     - --max-comments=${{ inputs.max_comments }}
     - --lgtm-comment-body='${{ inputs.lgtm_comment_body }}'

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,10 @@ inputs:
     description: 'Comma-separated list of apt packages to install'
     required: false
     default: ''
+  install_commands:
+    description: 'Commands to execute after `apt_packages` and before `cmake_command`'
+    required: false
+    default: ''
   cmake_command:
     description: 'If set, run CMake as part of the action using this command'
     required: false
@@ -87,6 +91,7 @@ runs:
     - --include='${{ inputs.include }}'
     - --exclude='${{ inputs.exclude }}'
     - --apt-packages=${{ inputs.apt_packages }}
+    - --install-commands=${{ inputs.install_commands }}
     - --cmake-command='${{ inputs.cmake_command }}'
     - --max-comments=${{ inputs.max_comments }}
     - --lgtm-comment-body='${{ inputs.lgtm_comment_body }}'

--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -78,6 +78,12 @@ def main():
         default="",
     )
     parser.add_argument(
+        "--install-commands",
+        help="Comma-separated list of shell commands to execute",
+        type=str,
+        default="",
+    )
+    parser.add_argument(
         "--cmake-command",
         help="If set, run CMake as part of the action with this command",
         type=str,
@@ -140,6 +146,11 @@ def main():
                 ["apt-get", "install", "-y", "--no-install-recommends", *apt_packages],
                 check=True,
             )
+
+    if args.install_commands:
+        install_commands = args.install_commands
+        with message_group(f"Running additional install commands: {install_commands}"):
+            subprocess.run(install_commands, shell=True, check=True)
 
     build_compile_commands = f"{args.build_dir}/compile_commands.json"
 

--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -147,8 +147,9 @@ def main():
                 check=True,
             )
 
-    if args.install_commands:
-        install_commands = args.install_commands
+    install_commands = strip_enclosing_quotes(args.install_commands)
+    
+    if install_commands:
         with message_group(f"Running additional install commands: {install_commands}"):
             subprocess.run(install_commands, shell=True, check=True)
 


### PR DESCRIPTION
sometimes just running apt-get install is not enough, so allow providing arbitrary installation commands

[note] I am aware that the commands can (currently) just be added to `cmake_command` but I do find that a bit ugly.