### PR TITLE
feat: allow extra clang-tidy arguments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'List of checks'
     default: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*'
     required: false
+  extra_arguments:
+    description: 'Extra arguments to pass to the clang-tidy invocation'
+    default: ''
+    required: false
   config_file:
     description: 'Location of .clang-tidy config file. If specified, takes preference over `clang_tidy_checks`'
     default: ''
@@ -87,6 +91,7 @@ runs:
     - --build_dir=${{ inputs.build_dir }}
     - --base_dir=${{ inputs.base_dir }}
     - --clang_tidy_checks=${{ inputs.clang_tidy_checks }}
+    - --extra-arguments='${{ inputs.extra_arguments }}'
     - --config_file=${{ inputs.config_file }}
     - --include='${{ inputs.include }}'
     - --exclude='${{ inputs.exclude }}'

--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -929,6 +929,7 @@ def create_review(
     max_task: int,
     include: List[str],
     exclude: List[str],
+    extra_arguments: list[str],
 ) -> Optional[PRReview]:
     """Given the parameters, runs clang-tidy and creates a review.
     If no files were changed, or no warnings could be found, None will be returned.
@@ -987,6 +988,7 @@ def create_review(
         "--enable-check-profile",
         f"-store-check-profile={PROFILE_DIR}",
     ]
+    base_invocation += extra_arguments
     if config:
         print(f"Using config: {config}")
         base_invocation.append(config)

--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -7,6 +7,7 @@
 
 import argparse
 import re
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -52,6 +53,11 @@ def main():
         "--clang_tidy_checks",
         help="checks argument",
         default="'-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*'",
+    )
+    parser.add_argument(
+        "--extra-arguments",
+        help="Extra arguments to pass to the clang-tidy invocation",
+        default="",
     )
     parser.add_argument(
         "--config_file",
@@ -177,6 +183,7 @@ def main():
         args.parallel,
         include,
         exclude,
+        shlex.split(args.extra_arguments),
     )
 
     with message_group("Saving metadata"):


### PR DESCRIPTION
Sometimes, it's useful to be able to pass extra arguments to the invocation. My use-case is to be able to load Clazy (Qt clang-tidy checks) as a plugin through `-load`. This PR adds `extra_arguments` which is appended to the invocation (split with `shlex.split`).

Closes #89.