### PR TITLE
feat: support clang-tidy 20 and 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:25.10
 
 RUN apt update && \
     DEBIAN_FRONTEND=noninteractive \
@@ -11,6 +11,8 @@ RUN apt update && \
     clang-tidy-17 \
     clang-tidy-18 \
     clang-tidy-19 \
+    clang-tidy-20 \
+    clang-tidy-21 \
     python3 \
     python3-pip \
     && rm -rf /var/lib/apt/lists/

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ at once, so `clang-tidy-review` will only attempt to post the first
 - `base_dir`: Absolute path to initial working directory
   `GITHUB_WORKSPACE`.
   - default: `GITHUB_WORKSPACE`
-- `clang_tidy_version`: Version of clang-tidy to use; one of 14, 15, 16, 17, 18, 19
-  - default: '19'
+- `clang_tidy_version`: Version of clang-tidy to use; one of 14, 15, 16, 17, 18, 19, 20, 21
+  - default: '21'
 - `clang_tidy_checks`: List of checks
   - default: `'-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*'`
 - `config_file`: Path to clang-tidy config file, replaces `clang_tidy_checks`

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,8 @@ inputs:
     default: ${{ github.workspace }}
     require: false
   clang_tidy_version:
-    description: 'Version of clang-tidy to use; one of 14, 15, 16, 17, 18, 19'
-    default: '19'
+    description: 'Version of clang-tidy to use; one of 14, 15, 16, 17, 18, 19, 20, 21'
+    default: '21'
     required: false
   clang_tidy_checks:
     description: 'List of checks'


### PR DESCRIPTION
This PR adds support for clang-tidy from LLVM 20.1 and 21.1 by updating Ubuntu to 25.10.