### PR TITLE
docs: Update examples in readme to refer to current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ jobs:
 
     # Optionally generate compile_commands.json
 
-    - uses: ZedThree/clang-tidy-review@v0.14.0
+    - uses: ZedThree/clang-tidy-review@v0.21.0
       id: review
 
     # Uploads an artefact containing clang_fixes.json
-    - uses: ZedThree/clang-tidy-review/upload@v0.14.0
+    - uses: ZedThree/clang-tidy-review/upload@v0.21.0
       id: upload-review
 
     # If there are any comments, fail the check
@@ -147,7 +147,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: ZedThree/clang-tidy-review@v0.14.0
+    - uses: ZedThree/clang-tidy-review@v0.21.0
       id: review
       with:
         # List of packages to install
@@ -205,7 +205,7 @@ jobs:
     - name: Set base_dir
       run: echo "base_dir=$(pwd)" >> $GITHUB_ENV
 
-    - uses: ZedThree/clang-tidy-review@v0.14.0
+    - uses: ZedThree/clang-tidy-review@v0.21.0
       id: review
       with:
         # Tell clang-tidy-review the base directory.
@@ -236,11 +236,11 @@ jobs:
 
     # Optionally generate compile_commands.json
 
-    - uses: ZedThree/clang-tidy-review@v0.14.0
+    - uses: ZedThree/clang-tidy-review@v0.21.0
       with:
         split_workflow: true
 
-    - uses: ZedThree/clang-tidy-review/upload@v0.14.0
+    - uses: ZedThree/clang-tidy-review/upload@v0.21.0
 ```
 The `clang-tidy-review/upload` Action will automatically upload the following
 files as workflow artefacts:
@@ -266,7 +266,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ZedThree/clang-tidy-review/post@v0.14.0
+      - uses: ZedThree/clang-tidy-review/post@v0.21.0
         # lgtm_comment_body, max_comments, and annotations need to be set on the posting workflow in a split setup
         with:
           # adjust options as necessary


### PR DESCRIPTION
The examples referred to v0.14.0 while v0.21.0 is the latest one.