### PR TITLE
Add extra commentable lines to clang-tidy review 

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ at once, so `clang-tidy-review` will only attempt to post the first
   annotations can be written fully, the rest will be summarised. This is a
   limitation of the GitHub API.
 - `num_comments_as_exitcode`: Set the exit code to be the amount of comments (enabled by default).
+- `extra_arguments`: Extra arguments to pass to the clang-tidy invocation.
+- `include_context_lines`: Include the 3 context lines above and below changes. These can still be commented on in Github Reviews (disabled by default).
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,10 @@ inputs:
     description: "Number of tidy instances to be run in parallel. Zero will automatically determine the right number."
     required: false
     default: "0"
+  include_context_lines:
+    description: "Include the 3 context lines above and below changes. These can still be commented on in Github Reviews."
+    required: false
+    default: false
   pr:
     default: ${{ github.event.pull_request.number }}
   repo:
@@ -103,3 +107,4 @@ runs:
     - --split_workflow=${{ inputs.split_workflow }}
     - --annotations=${{ inputs.annotations }}
     - --parallel=${{ inputs.parallel }}
+    - --include-context-lines=${{ inputs.include_context_lines }}

--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -130,6 +130,12 @@ def main():
         default=0,
     )
     parser.add_argument(
+        "--include-context-lines",
+        help="Include the 3 context lines above and below changes. These can still be commented on in Github Reviews.",
+        type=bool_argument,
+        default=False,
+    )
+    parser.add_argument(
         "--dry-run", help="Run and generate review, but don't post", action="store_true"
     )
     add_auth_arguments(parser)
@@ -181,9 +187,10 @@ def main():
         args.clang_tidy_binary,
         args.config_file,
         args.parallel,
+        args.include_context_lines,
+        shlex.split(args.extra_arguments),
         include,
         exclude,
-        shlex.split(args.extra_arguments),
     )
 
     with message_group("Saving metadata"):


### PR DESCRIPTION
(Co-created with AI assistants Claude and ChatGPT)
Implements #147 

## Summary
Enhance the `get_line_ranges` function to support context-aware line filtering for clang-tidy review.

## Problem
The original implementation only checked lines that were **added** in a pull request. This missed cases where clang-tidy suggests fixes that require removal of code, such as `modernize-use-equals-default`.

Example:
```diff
 MyClass::~MyClass() {  // Context line
-    delete m_Member1;  // Changed line
-    delete m_Member2;  // Changed line
-    delete m_Member3;  // Changed line
 }                      // Context line
```
Should be simplified to:
```cpp
MyClass::~MyClass() = default;
```

But the old implementation wouldn't detect this because no lines were added, only removed.

## Solution
Modified `get_line_ranges` to optionally include context lines from unidiff which seem to match one to one with the context lines in github reviews.

## Testing
- Updated existing `test_line_ranges()` to explicitly not include context lines
- Added variations on `test_line_ranges()` which do include context lines.
