### PR TITLE
Bugfix: Fix path error on windows runners

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -1216,8 +1216,8 @@ def get_line_ranges(diff, files):
         # However, clang.exe on windows expects forward slashes.
         # Adding a copy of the line filters with backslashes allows for both cl.exe and clang.exe to work.
         if os.path.sep == "\\":
-            # Converts name to backslashes for the cl.exe line filter.
-            name = Path.joinpath(*name.split("/"))
+            # Converts name to backslashes for the cl.exe line filter using `WindowsPath.__str__`
+            name = str(Path(name))
             line_filter_json.append({"name": name, "lines": lines})
     return json.dumps(line_filter_json, separators=(",", ":"))
 


### PR DESCRIPTION
`Path.joinpath` does not work on a list of strings and therefore causes an exception.