### PR TITLE
fix: remove unavailable clang-tidy versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ RUN apt update && \
     build-essential cmake git \
     tzdata \
     clang-tidy-14 \
-    clang-tidy-15 \
-    clang-tidy-16 \
     clang-tidy-17 \
     clang-tidy-18 \
     clang-tidy-19 \

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ at once, so `clang-tidy-review` will only attempt to post the first
 - `base_dir`: Absolute path to initial working directory
   `GITHUB_WORKSPACE`.
   - default: `GITHUB_WORKSPACE`
-- `clang_tidy_version`: Version of clang-tidy to use; one of 14, 15, 16, 17, 18, 19, 20, 21
+- `clang_tidy_version`: Version of clang-tidy to use; one of 14, 17, 18, 19, 20, 21
   - default: '21'
 - `clang_tidy_checks`: List of checks
   - default: `'-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*'`

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     default: ${{ github.workspace }}
     require: false
   clang_tidy_version:
-    description: 'Version of clang-tidy to use; one of 14, 15, 16, 17, 18, 19, 20, 21'
+    description: 'Version of clang-tidy to use; one of 14, 17, 18, 19, 20, 21'
     default: '21'
     required: false
   clang_tidy_checks:


### PR DESCRIPTION
It seems like Ubuntu 25.10 dropped support for clang-tidy-15 and -16, while -14 is still available. I must've only checked -14 to exist when I updated the container image.

Ubuntu 25.04 already dropped clang-tidy-16, but kept -14 and -15.

Searching for [`/clang_tidy_version: 16/`](https://github.com/search?q=%2Fclang_tidy_version%3A+16%2F&type=code) only shows two projects that set this version. Both use an older version of this action. [`/clang_tidy_version: 15/`](https://github.com/search?q=%2Fclang_tidy_version%3A+15%2F&type=code) doesn't show any project using this action.