### PR TITLE
feat: annotate more functions and variables with types

### DIFF
--- a/post/clang_tidy_review/pyproject.toml
+++ b/post/clang_tidy_review/pyproject.toml
@@ -65,3 +65,6 @@ extend-select = [
   "EXE",         # flake8-executable
   "FURB",        # refurb
 ]
+ignore = [
+  "UP045",       # non-pep604-annotation-optional
+]

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -368,11 +368,7 @@ def test_read_one_line():
 
 
 def test_format_diff_line():
-    source_line = "const std::string selective_hello(std::string name) {"
-
-    code_blocks, end_line = ctr.format_diff_line(
-        TEST_DIAGNOSTIC, TEST_OFFSET_LOOKUP, source_line, 0, 4
-    )
+    code_blocks, end_line = ctr.format_diff_line(TEST_DIAGNOSTIC, TEST_OFFSET_LOOKUP, 4)
 
     expected_replacement = textwrap.dedent(
         """


### PR DESCRIPTION
This adds a few more types to functions. Many functions at the top of  `__index__.py` were missing types. This should make it easier to author and review PRs.

`format_diff_line` contained two unused arguments, `source_line` and `line_offset`, which I removed.
