### PR TITLE
fix: remove quotes around extra arguments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ runs:
     - --build_dir=${{ inputs.build_dir }}
     - --base_dir=${{ inputs.base_dir }}
     - --clang_tidy_checks=${{ inputs.clang_tidy_checks }}
-    - --extra-arguments='${{ inputs.extra_arguments }}'
+    - --extra-arguments=${{ inputs.extra_arguments }}
     - --config_file=${{ inputs.config_file }}
     - --include='${{ inputs.include }}'
     - --exclude='${{ inputs.exclude }}'


### PR DESCRIPTION
This allows you to specify multiple extra arguments

Without this, the list of arguments would be parsed as a single argument (i.e. `--load=a --load=b` parsed as `--load="a --load=b"`)

Another alternative would be to call `strip_enclosing_quotes` inside `review.py`.

Tested this here [Chatterino/chatterino2@`97c5f1d` (#6626)](https://github.com/Chatterino/chatterino2/pull/6626/commits/97c5f1daa0eb2812c580ee7fd8707e876a742329) with the action run here https://github.com/Chatterino/chatterino2/actions/runs/19990152086/job/57329676381?pr=6626

Also tested [Chatterino/chatterino2@`b9e63b7` (#6626)](https://github.com/Chatterino/chatterino2/pull/6626/commits/b9e63b718ba82a2f88086e4323b7d64debdf9360) with the action run here https://github.com/Chatterino/chatterino2/actions/runs/19990248043/job/57329913735?pr=6626 to ensure it works when the user quotes the workflow yaml, but it makes no difference.