### PR TITLE
chore: add option for error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ at once, so `clang-tidy-review` will only attempt to post the first
 - `include_context_lines`: Include the 3 context lines above and below changes (default: false).
   This is useful when removing lines, as it allows `clang-tidy` to raise warnings on the context
   around deleted lines.
+- `error_action`: Action to take when encountering compile errors from Clang (clang-diagnostic-error).
+  'post' (default) will post the error as-is. 'skip' will ignore the error but post other errors.
+  'abort' will stop the action with an error if one is found.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,10 @@ inputs:
     description: "Include the 3 context lines above and below changes (default: false). This is useful when removing lines, as it allows `clang-tidy` to raise warnings on the context  around deleted lines. Include the 3 context lines above and below changes. These can still be commented on in Github Reviews."
     required: false
     default: false
+  error_action:
+    description: "Action to take when encountering compile errors from Clang (clang-diagnostic-error). 'post' (default) will post the error as-is. 'skip' will ignore the error but post other errors. 'abort' will stop the action with an error if one is found."
+    required: false
+    default: post
   pr:
     default: ${{ github.event.pull_request.number }}
   repo:
@@ -108,3 +112,4 @@ runs:
     - --annotations=${{ inputs.annotations }}
     - --parallel=${{ inputs.parallel }}
     - --include-context-lines=${{ inputs.include_context_lines }}
+    - --error-action=${{ inputs.error_action }}

--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -135,6 +135,13 @@ def main():
         default=False,
     )
     parser.add_argument(
+        "--error-action",
+        help="Action to take when encountering compile errors from Clang (clang-diagnostic-error).",
+        type=str,
+        default="post",
+        choices=("post", "skip", "abort"),
+    )
+    parser.add_argument(
         "--dry-run", help="Run and generate review, but don't post", action="store_true"
     )
     add_auth_arguments(parser)
@@ -190,6 +197,7 @@ def main():
         args.extra_arguments,
         include,
         exclude,
+        args.error_action,
     )
 
     with message_group("Saving metadata"):


### PR DESCRIPTION
Quite often, we have PRs that don't build. The most common reason being missing includes (that would otherwise be in a PCH).
When clang-tidy runs on these files, it picks up the errors Clang would generate. In many cases, one error results in others down the line, so the comments fill up. This creates unwanted noise.

To help with this, I added an option to deal with errors when creating a review. Users can set `error_action` to:
- `post` (default): Don't do any special handling - post errors like before.
- `skip`: Don't post errors (but post warnings from that invocation).
- `abort`: Fail the action with an error if there are any errors when running clang-tidy.

Also did a test here: https://github.com/Nerixyz/test-mini-cpp-project/pull/16.