### PR TITLE
feat: Update Docker image to Ubuntu 26.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM ubuntu:25.10
+FROM ubuntu:26.04
 
 RUN apt update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends\
     build-essential cmake git \
     tzdata \
-    clang-tidy-14 \
     clang-tidy-17 \
     clang-tidy-18 \
     clang-tidy-19 \
     clang-tidy-20 \
     clang-tidy-21 \
+    clang-tidy-22 \
     python3 \
     python3-pip \
     && rm -rf /var/lib/apt/lists/

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ at once, so `clang-tidy-review` will only attempt to post the first
 - `base_dir`: Absolute path to initial working directory
   `GITHUB_WORKSPACE`.
   - default: `GITHUB_WORKSPACE`
-- `clang_tidy_version`: Version of clang-tidy to use; one of 14, 17, 18, 19, 20, 21
-  - default: '21'
+- `clang_tidy_version`: Version of clang-tidy to use; one of 17, 18, 19, 20, 21, 22
+  - default: '22'
 - `clang_tidy_checks`: List of checks
   - default: `'-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*'`
 - `config_file`: Path to clang-tidy config file, replaces `clang_tidy_checks`

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,8 @@ inputs:
     default: ${{ github.workspace }}
     require: false
   clang_tidy_version:
-    description: 'Version of clang-tidy to use; one of 14, 17, 18, 19, 20, 21'
-    default: '21'
+    description: 'Version of clang-tidy to use; one of 17, 18, 19, 20, 21, 22'
+    default: '22'
     required: false
   clang_tidy_checks:
     description: 'List of checks'


### PR DESCRIPTION
This adds clang-tidy-22 but also removes clang-tidy-14. 22 should also skip the system headers (#165).

Tested here: https://github.com/Nerixyz/test-mini-cpp-project/pull/17