### PR TITLE
Remove python 10+ syntax so runners with older python can use script

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -304,7 +304,7 @@ def merge_replacement_files(tmpdir: Path, mergefile: Path) -> None:
     merged: list[ClangDiagnostic] = []
     for replacefile in tmpdir.glob("*.yaml"):
         with replacefile.open() as f:
-            content: ClangTUDiagnostics | None = yaml.safe_load(f)
+            content: Optional[ClangTUDiagnostics] = yaml.safe_load(f)
         if not content:
             continue  # Skip empty files.
         merged.extend(content.get(mergekey, []))
@@ -1405,11 +1405,11 @@ def decorate_check_names(comment: str) -> str:
     regex = r"\[(((?:clang-analyzer)|(?:(?!clang)[\w]+))-([\.\w-]+))\]$"
 
     def repl(m: re.Match[str]) -> str:
-        match m.group(2):
-            case "clazy":
-                url = f"https://invent.kde.org/sdk/clazy/-/blob/master/docs/checks/README-{m.group(3)}.md"
-            case other:
-                url = f"https://clang.llvm.org/extra/clang-tidy/checks/{other}/{m.group(3)}.html"
+        checker = m.group(2)
+        if checker == "clazy":
+            url = f"https://invent.kde.org/sdk/clazy/-/blob/master/docs/checks/README-{m.group(3)}.md"
+        else:
+            url = f"https://clang.llvm.org/extra/clang-tidy/checks/{checker}/{m.group(3)}.html"
         return f"[[{m.group(1)}]({url})]"
 
     return re.sub(regex, repl, comment, count=1, flags=re.MULTILINE)

--- a/post/clang_tidy_review/pyproject.toml
+++ b/post/clang_tidy_review/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 ]
 keywords = ["C++", "static-analysis"]
 dynamic = ["version"]
-requires-python = ">= 3.10"
+requires-python = ">= 3.8"
 
 [project.urls]
 source = "https://github.com/ZedThree/clang-tidy-review"


### PR DESCRIPTION
The commit #149 bumped the minimum python requirement which excludes potential older runners for some very basic syntactic sugar.

This PR restores support for python 3.8 and 3.9